### PR TITLE
Add date range filtering to queue jobs

### DIFF
--- a/friend/backends/advanced/src/advanced_omi_backend/controllers/queue_controller.py
+++ b/friend/backends/advanced/src/advanced_omi_backend/controllers/queue_controller.py
@@ -10,6 +10,7 @@ This module provides:
 
 import os
 import logging
+from datetime import datetime, timezone
 from typing import Dict, Any, Optional
 
 import redis
@@ -88,8 +89,6 @@ async def _ensure_beanie_initialized():
 
 def get_job_stats() -> Dict[str, Any]:
     """Get statistics about jobs in all queues matching frontend expectations."""
-    from datetime import datetime
-
     total_jobs = 0
     queued_jobs = 0
     processing_jobs = 0
@@ -122,7 +121,43 @@ def get_job_stats() -> Dict[str, Any]:
     }
 
 
-def get_jobs(limit: int = 20, offset: int = 0, queue_name: str = None) -> Dict[str, Any]:
+def _normalize_datetime(dt_value: Optional[datetime]) -> Optional[datetime]:
+    if not dt_value:
+        return None
+
+    if dt_value.tzinfo:
+        return dt_value.astimezone(timezone.utc).replace(tzinfo=None)
+
+    return dt_value
+
+
+def _job_in_date_range(
+    timestamp: Optional[datetime],
+    start_date: Optional[datetime],
+    end_date: Optional[datetime],
+) -> bool:
+    if not start_date and not end_date:
+        return True
+
+    if timestamp is None:
+        return False
+
+    if start_date and timestamp < start_date:
+        return False
+
+    if end_date and timestamp > end_date:
+        return False
+
+    return True
+
+
+def get_jobs(
+    limit: int = 20,
+    offset: int = 0,
+    queue_name: str = None,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+) -> Dict[str, Any]:
     """
     Get jobs from a specific queue or all queues.
 
@@ -134,6 +169,9 @@ def get_jobs(limit: int = 20, offset: int = 0, queue_name: str = None) -> Dict[s
     Returns:
         Dict with jobs list and pagination metadata matching frontend expectations
     """
+    start_boundary = _normalize_datetime(start_date)
+    end_boundary = _normalize_datetime(end_date)
+
     all_jobs = []
 
     queues_to_check = [queue_name] if queue_name else [TRANSCRIPTION_QUEUE, MEMORY_QUEUE, DEFAULT_QUEUE]
@@ -155,6 +193,19 @@ def get_jobs(limit: int = 20, offset: int = 0, queue_name: str = None) -> Dict[s
                 try:
                     job = Job.fetch(job_id, connection=redis_conn)
 
+                    created_at = job.created_at
+                    started_at = job.started_at
+                    ended_at = job.ended_at
+                    reference_time = created_at or started_at or ended_at
+                    normalized_reference = _normalize_datetime(reference_time)
+
+                    if not _job_in_date_range(
+                        normalized_reference,
+                        start_boundary,
+                        end_boundary,
+                    ):
+                        continue
+
                     # Extract user_id from kwargs if present
                     user_id = job.kwargs.get("user_id", "") if job.kwargs else ""
 
@@ -173,19 +224,20 @@ def get_jobs(limit: int = 20, offset: int = 0, queue_name: str = None) -> Dict[s
                         },
                         "result": job.result if hasattr(job, 'result') else None,
                         "error_message": str(job.exc_info) if job.exc_info else None,
-                        "created_at": job.created_at.isoformat() if job.created_at else None,
-                        "started_at": job.started_at.isoformat() if job.started_at else None,
-                        "completed_at": job.ended_at.isoformat() if job.ended_at else None,
+                        "created_at": created_at.isoformat() if created_at else None,
+                        "started_at": started_at.isoformat() if started_at else None,
+                        "completed_at": ended_at.isoformat() if ended_at else None,
                         "retry_count": job.retries_left if hasattr(job, 'retries_left') else 0,
                         "max_retries": 3,  # Default max retries
                         "progress_percent": 0,  # RQ doesn't track progress by default
                         "progress_message": "",
+                        "_sort_time": normalized_reference or datetime.min,
                     })
                 except Exception as e:
                     logger.error(f"Error fetching job {job_id}: {e}")
 
     # Sort by created_at (most recent first)
-    all_jobs.sort(key=lambda x: x.get("created_at") or "", reverse=True)
+    all_jobs.sort(key=lambda x: x.get("_sort_time", datetime.min), reverse=True)
 
     # Paginate
     total_jobs = len(all_jobs)
@@ -193,7 +245,10 @@ def get_jobs(limit: int = 20, offset: int = 0, queue_name: str = None) -> Dict[s
     has_more = (offset + limit) < total_jobs
 
     return {
-        "jobs": paginated_jobs,
+        "jobs": [
+            {key: value for key, value in job.items() if key != "_sort_time"}
+            for job in paginated_jobs
+        ],
         "pagination": {
             "total": total_jobs,
             "limit": limit,

--- a/friend/backends/advanced/src/advanced_omi_backend/routers/modules/queue_routes.py
+++ b/friend/backends/advanced/src/advanced_omi_backend/routers/modules/queue_routes.py
@@ -4,6 +4,7 @@ Provides basic endpoints for viewing job status and statistics.
 """
 
 import logging
+from datetime import datetime
 from fastapi import APIRouter, Depends, Query, HTTPException
 from pydantic import BaseModel
 from typing import List, Optional
@@ -23,11 +24,33 @@ async def list_jobs(
     limit: int = Query(20, ge=1, le=100, description="Number of jobs to return"),
     offset: int = Query(0, ge=0, description="Number of jobs to skip"),
     queue_name: str = Query(None, description="Filter by queue name"),
+    start_date: Optional[datetime] = Query(
+        None,
+        alias="startDate",
+        description="Only include jobs created after this timestamp",
+    ),
+    end_date: Optional[datetime] = Query(
+        None,
+        alias="endDate",
+        description="Only include jobs created before this timestamp",
+    ),
     current_user: User = Depends(current_active_user)
 ):
     """List jobs with pagination and filtering."""
     try:
-        result = get_jobs(limit=limit, offset=offset, queue_name=queue_name)
+        if start_date and end_date and end_date < start_date:
+            raise HTTPException(
+                status_code=400,
+                detail="endDate must be after startDate",
+            )
+
+        result = get_jobs(
+            limit=limit,
+            offset=offset,
+            queue_name=queue_name,
+            start_date=start_date,
+            end_date=end_date,
+        )
 
         # Filter jobs by user if not admin
         if not current_user.is_superuser:

--- a/friend/backends/advanced/tests/test_queue_filters.py
+++ b/friend/backends/advanced/tests/test_queue_filters.py
@@ -1,0 +1,26 @@
+from datetime import datetime, timedelta, timezone
+
+from advanced_omi_backend.controllers.queue_controller import _job_in_date_range, _normalize_datetime
+
+
+def test_job_in_date_range_respects_boundaries():
+    base = datetime(2024, 5, 1, 12, 0, tzinfo=timezone.utc)
+    start = base - timedelta(hours=1)
+    end = base + timedelta(hours=1)
+
+    normalized_base = _normalize_datetime(base)
+    normalized_start = _normalize_datetime(start)
+    normalized_end = _normalize_datetime(end)
+
+    assert _job_in_date_range(normalized_base, normalized_start, normalized_end)
+    assert not _job_in_date_range(normalized_base, normalized_end, None)
+    assert not _job_in_date_range(normalized_base, None, normalized_start)
+    assert not _job_in_date_range(None, normalized_start, normalized_end)
+
+
+def test_normalize_datetime_converts_timezone_to_naive_utc():
+    aware_time = datetime(2024, 5, 1, 8, 0, tzinfo=timezone(timedelta(hours=-4)))
+    normalized = _normalize_datetime(aware_time)
+
+    assert normalized.tzinfo is None
+    assert normalized == datetime(2024, 5, 1, 12, 0)

--- a/friend/backends/advanced/webui/src/pages/Queue.tsx
+++ b/friend/backends/advanced/webui/src/pages/Queue.tsx
@@ -135,6 +135,7 @@ const Queue: React.FC = () => {
     job_type: '',
     priority: ''
   });
+  const [dateRange, setDateRange] = useState({ startDate: '', endDate: '' });
   const [pagination, setPagination] = useState({
     offset: 0,
     limit: 20,
@@ -265,7 +266,7 @@ const Queue: React.FC = () => {
   // Initial data fetch
   useEffect(() => {
     fetchData();
-  }, [filters, pagination.offset, fetchData]);
+  }, [filters, dateRange, pagination.offset, fetchData]);
 
   const fetchJobs = async () => {
     try {
@@ -279,6 +280,8 @@ const Queue: React.FC = () => {
       if (filters.status) params.append('status', filters.status);
       if (filters.job_type) params.append('job_type', filters.job_type);
       if (filters.priority) params.append('priority', filters.priority);
+      if (dateRange.startDate) params.append('startDate', new Date(dateRange.startDate).toISOString());
+      if (dateRange.endDate) params.append('endDate', new Date(dateRange.endDate).toISOString());
 
       const response = await queueApi.getJobs(params);
       const data = response.data;
@@ -408,12 +411,18 @@ const Queue: React.FC = () => {
   };
 
   const applyFilters = () => {
+    if (dateRange.startDate && dateRange.endDate && new Date(dateRange.endDate) < new Date(dateRange.startDate)) {
+      alert('End date must be after start date');
+      return;
+    }
+
     setPagination(prev => ({ ...prev, offset: 0 }));
     fetchJobs();
   };
 
   const clearFilters = () => {
     setFilters({ status: '', job_type: '', priority: '' });
+    setDateRange({ startDate: '', endDate: '' });
     setPagination(prev => ({ ...prev, offset: 0 }));
   };
 
@@ -1286,7 +1295,7 @@ const Queue: React.FC = () => {
       {/* Filters */}
       <div className="bg-white rounded-lg border p-4">
         <h3 className="text-lg font-medium mb-4">Filters</h3>
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
             <select
@@ -1331,6 +1340,26 @@ const Queue: React.FC = () => {
               <option value="normal">Normal</option>
               <option value="low">Low</option>
             </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Date Range</label>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              <input
+                type="datetime-local"
+                value={dateRange.startDate}
+                onChange={(e) => setDateRange({ ...dateRange, startDate: e.target.value })}
+                className="w-full border border-gray-300 rounded-md px-3 py-2"
+                aria-label="Start date"
+              />
+              <input
+                type="datetime-local"
+                value={dateRange.endDate}
+                onChange={(e) => setDateRange({ ...dateRange, endDate: e.target.value })}
+                className="w-full border border-gray-300 rounded-md px-3 py-2"
+                aria-label="End date"
+              />
+            </div>
           </div>
 
           <div className="flex items-end space-x-2">


### PR DESCRIPTION
## Summary
- add startDate/endDate validation to the queue jobs API and filter jobs by timestamp in the controller
- expose a date range picker in the queue dashboard and forward the selected window to the backend
- cover the date filtering helpers with unit tests

## Testing
- uv run pytest tests/test_queue_filters.py *(fails: dependency download blocked in CI environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692898637b508322b79ba306652ff2c7)