### PR TITLE
Add restore option to object history

### DIFF
--- a/frontend/src/pages/ObjectHistoryPage.tsx
+++ b/frontend/src/pages/ObjectHistoryPage.tsx
@@ -2,7 +2,12 @@ import { useParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { History, ChevronDown, ChevronUp } from "lucide-react";
 import { SmartBackButton } from "@/components/SmartBackButton";
-import { useObject, useObjectHistory } from "@/hooks/useObjectQueries";
+import {
+  useObject,
+  useObjectHistory,
+  useUpdateObject,
+  objectKeys,
+} from "@/hooks/useObjectQueries";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { formatDistanceToNow } from "date-fns";
@@ -14,6 +19,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { useQueryClient } from "@tanstack/react-query";
 
 import yaml from "yaml";
 
@@ -47,9 +53,12 @@ function removeEmptyValues(value: any): any {
 
 
 function formatValue(value: any): string {
-  return yaml.stringify(removeEmptyValues(EJSON.serialize(value)), {
-    indent: 2, sortMapEntries: true, 
- }).trim();
+  return yaml
+    .stringify(removeEmptyValues(EJSON.serialize(value)), {
+      indent: 2,
+      sortMapEntries: true,
+    })
+    .trim();
 }
 
 function getActionBadgeVariant(action: string) {
@@ -148,10 +157,9 @@ function getGroupedState(group: HistoryEntry[]): {
 function CodeBlock({ value, variant = "before" }: { value: any; variant?: "before" | "after" }) {
   const formatted = useMemo(() => formatValue(value), [value]);
   const isEmpty = formatted === 'null';
-  console.log("formatted", formatted);
   const isBefore = variant === "before";
   return (
-    <div className={isBefore 
+    <div className={isBefore
       ? "bg-red-50 dark:bg-red-950/20 p-2 rounded border border-red-200 dark:border-red-900"
       : "bg-green-50 dark:bg-green-950/20 p-2 rounded border border-green-200 dark:border-green-900"
     }>
@@ -168,7 +176,17 @@ function CodeBlock({ value, variant = "before" }: { value: any; variant?: "befor
   );
 }
 
-function HistoryEntryCard({ entry }: { entry: HistoryEntry }) {
+function HistoryEntryCard({
+  entry,
+  onRestore,
+  isRestoring,
+  canRestore,
+}: {
+  entry: HistoryEntry;
+  onRestore?: () => void;
+  isRestoring?: boolean;
+  canRestore?: boolean;
+}) {
   return (
     <Card className="p-4">
       <div className="space-y-2">
@@ -243,15 +261,36 @@ function HistoryEntryCard({ entry }: { entry: HistoryEntry }) {
               </div>
             </div>
           )}
+
+          {entry.action === "update" && entry.field && onRestore && (
+            <div className="flex justify-end">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onRestore}
+                disabled={!canRestore || isRestoring}
+              >
+                {isRestoring ? "Restoring..." : "Restore value"}
+              </Button>
+            </div>
+          )}
       </div>
     </Card>
   );
 }
 
-function GroupedHistoryCard({ 
-  group
-}: { 
+function GroupedHistoryCard({
+  group,
+  onRestore,
+  isRestoring,
+  restoreKey,
+  canRestore,
+}: {
   group: HistoryEntry[];
+  onRestore?: (changes: { field: string; value: any }[], groupId: string) => void;
+  isRestoring?: boolean;
+  restoreKey: string;
+  canRestore?: boolean;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const { before, after, entries } = getGroupedState(group);
@@ -280,7 +319,28 @@ function GroupedHistoryCard({
               {formatDistanceToNow(lastTime, { addSuffix: true })}
             </span>
           </div>
-            
+
+            {onRestore && (
+              <div className="flex justify-end">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onRestore(
+                    entries
+                      .filter((entry) => entry.field)
+                      .map((entry) => ({
+                        field: entry.field!,
+                        value: before[entry.field!] ?? null,
+                      })),
+                    restoreKey,
+                  )}
+                  disabled={!canRestore || isRestoring}
+                >
+                  {isRestoring ? "Restoring..." : "Restore to this state"}
+                </Button>
+              </div>
+            )}
+
             {!isExpanded && (
               <div className="grid grid-cols-2 gap-4 text-sm" style={{ gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))" }}>
                 <div>
@@ -314,13 +374,21 @@ function GroupedHistoryCard({
               </Button>
             </CollapsibleTrigger>
             
-            <CollapsibleContent className="mt-4">
+              <CollapsibleContent className="mt-4">
               <div className="pt-2 border-t space-y-4">
                 <p className="text-sm font-medium mb-2 text-muted-foreground">
                   Individual changes:
                 </p>
                 {entries.map((entry) => (
-                  <HistoryEntryCard key={entry._id} entry={entry} />
+                  <HistoryEntryCard
+                    key={entry._id}
+                    entry={entry}
+                    onRestore={onRestore ? () => onRestore([
+                      { field: entry.field!, value: entry.oldValue ?? null },
+                    ], entry._id) : undefined}
+                    isRestoring={isRestoring}
+                    canRestore={canRestore}
+                  />
                 ))}
               </div>
             </CollapsibleContent>
@@ -332,13 +400,50 @@ function GroupedHistoryCard({
 
 const ObjectHistoryPage = () => {
   const { id } = useParams<{ id: string }>();
+  const queryClient = useQueryClient();
   const { data: object, isLoading: objectLoading } = useObject(id);
+  const updateObject = useUpdateObject();
   const {
     data: history,
     isLoading: historyLoading,
     error: historyError,
   } = useObjectHistory(id);
-  
+  const [restoringKey, setRestoringKey] = useState<string | null>(null);
+  const [restoreError, setRestoreError] = useState<string | null>(null);
+
+  const handleRestore = async (
+    changes: { field: string; value: any }[],
+    key: string,
+  ) => {
+    if (!object || !id) return;
+
+    setRestoreError(null);
+    setRestoringKey(key);
+    try {
+      let version = object.version ?? 0;
+
+      for (const change of changes) {
+        const result = await updateObject.mutateAsync({
+          id,
+          version,
+          field: change.field,
+          value: change.value ?? null,
+        });
+        version = result.version ?? version + 1;
+      }
+
+      queryClient.invalidateQueries({ queryKey: objectKeys.history(id) });
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to restore changes";
+      setRestoreError(message);
+    } finally {
+      setRestoringKey(null);
+    }
+  };
+
   // Group history entries
   const groupedHistory = history ? groupHistoryEntries(history) : [];
   
@@ -407,6 +512,14 @@ const ObjectHistoryPage = () => {
         </Card>
       )}
 
+      {restoreError && (
+        <Card className="p-4 border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/20">
+          <p className="text-red-600 dark:text-red-400">
+            Restore failed: {restoreError}
+          </p>
+        </Card>
+      )}
+
       {historyLoading && (
         <div className="border rounded-lg p-8 text-center">
           <p className="text-muted-foreground">Loading history...</p>
@@ -428,16 +541,30 @@ const ObjectHistoryPage = () => {
                 if (Array.isArray(item)) {
                   // Grouped entries
                   const groupId = item.map(e => e._id).join("-");
-                  
+
                   return (
                     <GroupedHistoryCard
                       key={groupId}
                       group={item}
+                      onRestore={object ? handleRestore : undefined}
+                      isRestoring={restoringKey === groupId}
+                      restoreKey={groupId}
+                      canRestore={!!object && !updateObject.isPending}
                     />
                   );
                 } else {
                   // Single entry
-                  return <HistoryEntryCard key={item._id} entry={item} />;
+                  return (
+                    <HistoryEntryCard
+                      key={item._id}
+                      entry={item}
+                      onRestore={object ? () => handleRestore([
+                        { field: item.field!, value: item.oldValue ?? null },
+                      ], item._id) : undefined}
+                      isRestoring={restoringKey === item._id}
+                      canRestore={!!object && !updateObject.isPending}
+                    />
+                  );
                 }
               })}
               {history.length >= 50 && (


### PR DESCRIPTION
## Summary
- add restore controls to the object history page for individual updates and grouped changes
- wire history restoration to the existing object update API with version-aware sequential updates and error handling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69438b82d3b88322845215ce831137ce)