### PR TITLE
Add retry functionality for failed jobs and add connectivity checks

### DIFF
--- a/backend/app/lib/jobs/workers.ts
+++ b/backend/app/lib/jobs/workers.ts
@@ -13,29 +13,59 @@ const SERVER_CONFIG_ID = new ObjectId("000000000000000000000000");
 
 const workers: Worker[] = [];
 
+type FailedType = "offline" | "internal" | undefined;
+
 /**
- * Detect if an error is network-related (offline mode)
+ * Classify error type to distinguish between:
+ * - "offline": External/internet errors (DNS, external API unreachable)
+ * - "internal": Internal service errors (backend/mongo connection refused)
+ * - undefined: Other errors
  */
-function isNetworkError(reason: string | undefined): boolean {
-  if (!reason) return false;
-  const networkErrorPatterns = [
-    "dns error",
-    "client error (Connect)",
-    "Name or service not known",
-    "network error",
-    "ENOTFOUND",
-    "ECONNREFUSED",
-    "ETIMEDOUT",
-    "ENETUNREACH",
-    "EHOSTUNREACH",
-    "getaddrinfo",
-    "unable to connect",
-    "connection refused",
+function classifyError(reason: string | undefined): FailedType {
+  if (!reason) return undefined;
+  const lower = reason.toLowerCase();
+
+  // Internal service patterns (Docker internal network)
+  const internalPatterns = [
+    "backend:5173",
+    "localhost:",
+    "mongo:",
+    "redis:",
+    "127.0.0.1",
+    "python-worker:",
   ];
-  const lowerReason = reason.toLowerCase();
-  return networkErrorPatterns.some(pattern => 
-    lowerReason.includes(pattern.toLowerCase())
-  );
+  const isInternal = internalPatterns.some(p => lower.includes(p));
+
+  // Connection error patterns
+  const connectionPatterns = [
+    "connection refused",
+    "econnrefused",
+  ];
+  const isConnectionError = connectionPatterns.some(p => lower.includes(p));
+
+  // If connection refused to internal service, it's an internal error
+  if (isConnectionError && isInternal) {
+    return "internal";
+  }
+
+  // External/offline error patterns
+  const offlinePatterns = [
+    "dns error",
+    "name or service not known",
+    "enetunreach",
+    "ehostunreach",
+    "getaddrinfo",
+  ];
+  if (offlinePatterns.some(p => lower.includes(p))) {
+    return "offline";
+  }
+
+  // Connection refused to external service = offline
+  if (isConnectionError && !isInternal) {
+    return "offline";
+  }
+
+  return undefined;
 }
 
 export async function startWorkers() {
@@ -110,10 +140,10 @@ export async function startWorkers() {
       const mongo = await getMongoResource(auth);
       const finishedAt = new Date();
       
-      // Detect if this is a network/offline error
-      const failedType = isNetworkError(failedReason) ? "offline" : undefined;
-      if (failedType === "offline") {
-        console.log(`[${jobType}] Job ${jobId} failed due to network error (offline)`);
+      // Classify error type (offline, internal, or undefined)
+      const failedType = classifyError(failedReason);
+      if (failedType) {
+        console.log(`[${jobType}] Job ${jobId} failed with type: ${failedType}`);
       }
       
       await mongo({

--- a/backend/app/lib/jobs/workers.ts
+++ b/backend/app/lib/jobs/workers.ts
@@ -13,6 +13,31 @@ const SERVER_CONFIG_ID = new ObjectId("000000000000000000000000");
 
 const workers: Worker[] = [];
 
+/**
+ * Detect if an error is network-related (offline mode)
+ */
+function isNetworkError(reason: string | undefined): boolean {
+  if (!reason) return false;
+  const networkErrorPatterns = [
+    "dns error",
+    "client error (Connect)",
+    "Name or service not known",
+    "network error",
+    "ENOTFOUND",
+    "ECONNREFUSED",
+    "ETIMEDOUT",
+    "ENETUNREACH",
+    "EHOSTUNREACH",
+    "getaddrinfo",
+    "unable to connect",
+    "connection refused",
+  ];
+  const lowerReason = reason.toLowerCase();
+  return networkErrorPatterns.some(pattern => 
+    lowerReason.includes(pattern.toLowerCase())
+  );
+}
+
 export async function startWorkers() {
   console.log("Starting job workers...");
 
@@ -84,6 +109,13 @@ export async function startWorkers() {
       const auth = await getServerAuth();
       const mongo = await getMongoResource(auth);
       const finishedAt = new Date();
+      
+      // Detect if this is a network/offline error
+      const failedType = isNetworkError(failedReason) ? "offline" : undefined;
+      if (failedType === "offline") {
+        console.log(`[${jobType}] Job ${jobId} failed due to network error (offline)`);
+      }
+      
       await mongo({
         action: "updateOne",
         collection: "jobs",
@@ -93,6 +125,7 @@ export async function startWorkers() {
             state: "failed", 
             finishedAt,
             failedReason: failedReason,
+            ...(failedType && { failedType }),
             updatedAt: new Date() 
           } 
         },
@@ -102,6 +135,7 @@ export async function startWorkers() {
         state: "failed",
         finishedOn: finishedAt.getTime(),
         failedReason: failedReason,
+        failedType,
       });
     });
 

--- a/backend/app/lib/resources/worker.ts
+++ b/backend/app/lib/resources/worker.ts
@@ -89,6 +89,15 @@ const GetWorkerStatusSchema = z.object({
   action: z.literal("get_worker_status"),
 });
 
+const RetryJobSchema = z.object({
+  action: z.literal("retry"),
+  id: z.string(),
+});
+
+const RetryAllOfflineSchema = z.object({
+  action: z.literal("retry_all_offline"),
+});
+
 const RequestSchema = z.union([
   UpdateProgressSchema,
   ListJobsSchema,
@@ -103,6 +112,8 @@ const RequestSchema = z.union([
   PauseAllSchema,
   ResumeAllSchema,
   GetWorkerStatusSchema,
+  RetryJobSchema,
+  RetryAllOfflineSchema,
 ]);
 
 type WorkerProgressRequest = z.infer<typeof RequestSchema>;
@@ -145,6 +156,10 @@ export class JobsResource
         return this.resumeAll(auth);
       case "get_worker_status":
         return this.getWorkerStatus(auth);
+      case "retry":
+        return this.retry(input, auth);
+      case "retry_all_offline":
+        return this.retryAllOffline(auth);
       default:
         throw new Error(`Unknown action: ${(input as any).action}`);
     }
@@ -181,6 +196,7 @@ export class JobsResource
       finishedOn: job.finishedAt?.getTime(),
       processedOn: job.startedAt?.getTime(),
       failedReason: job.failedReason,
+      failedType: job.failedType,
     };
   }
 
@@ -327,6 +343,7 @@ export class JobsResource
       finishedOn: job.finishedAt?.getTime(),
       processedOn: job.startedAt?.getTime(),
       failedReason: job.failedReason,
+      failedType: job.failedType,
     }));
   }
 
@@ -492,6 +509,100 @@ export class JobsResource
     });
   }
 
+  private async retry(input: z.infer<typeof RetryJobSchema>, auth: Auth) {
+    const mongo = await getMongoResource(auth);
+    const { id } = input;
+
+    // Find the failed job
+    const jobDocs = await mongo({
+      action: "find",
+      collection: "jobs",
+      query: { _id: new ObjectId(id) },
+      options: { limit: 1 },
+    });
+
+    const jobDoc = jobDocs[0];
+    if (!jobDoc) {
+      throw new Error(`Job ${id} not found`);
+    }
+
+    if (jobDoc.state !== "failed" && jobDoc.state !== "cancelled") {
+      throw new Error(`Job ${id} is not in a failed or cancelled state (current: ${jobDoc.state})`);
+    }
+
+    // Re-enqueue with the same data
+    const serverAuth = await getServerAuth();
+    const newJob = await enqueueJob(
+      { type: jobDoc.type, ...jobDoc.data },
+      {
+        trigger: {
+          type: "manual",
+          reason: `Retry of failed job ${id}`,
+        },
+      },
+      serverAuth
+    );
+
+    return {
+      success: true,
+      originalJobId: id,
+      newJobId: newJob.id,
+    };
+  }
+
+  private async retryAllOffline(auth: Auth) {
+    const mongo = await getMongoResource(auth);
+
+    // Find all jobs that failed due to offline/network errors
+    const failedJobs = await mongo({
+      action: "find",
+      collection: "jobs",
+      query: {
+        state: "failed",
+        failedType: "offline",
+      },
+      options: { limit: 100 },
+    });
+
+    if (failedJobs.length === 0) {
+      return {
+        success: true,
+        retriedCount: 0,
+        message: "No offline failures found to retry",
+      };
+    }
+
+    const serverAuth = await getServerAuth();
+    const retriedJobs: { originalId: string; newId: string }[] = [];
+
+    for (const jobDoc of failedJobs) {
+      try {
+        const newJob = await enqueueJob(
+          { type: jobDoc.type, ...jobDoc.data },
+          {
+            trigger: {
+              type: "manual",
+              reason: `Retry of offline failure ${jobDoc._id.toString()}`,
+            },
+          },
+          serverAuth
+        );
+        retriedJobs.push({
+          originalId: jobDoc._id.toString(),
+          newId: newJob.id,
+        });
+      } catch (err) {
+        console.error(`[jobs] Failed to retry job ${jobDoc._id}: ${err}`);
+      }
+    }
+
+    return {
+      success: true,
+      retriedCount: retriedJobs.length,
+      retriedJobs,
+    };
+  }
+
   extractActions(input: WorkerProgressRequest): {
     path: ResourcePath;
     actions: string[];
@@ -521,6 +632,10 @@ export class JobsResource
         return [{ path: ["jobs", "all"], actions: ["resume"] }];
       case "get_worker_status":
         return [{ path: ["jobs"], actions: ["read"] }];
+      case "retry":
+        return [{ path: ["jobs", input.id], actions: ["retry"] }];
+      case "retry_all_offline":
+        return [{ path: ["jobs", "all"], actions: ["retry"] }];
     }
     return [{ path: ["jobs"], actions: ["read", "write"] }];
   }

--- a/backend/app/routes/health.ts
+++ b/backend/app/routes/health.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from "express";
+import { getServerConfig } from "@/lib/config/serverConfig.server.ts";
 
 export async function rootHandler(_req: Request, res: Response) {
   res.json({
@@ -6,9 +7,89 @@ export async function rootHandler(_req: Request, res: Response) {
   });
 }
 
+// Cache connectivity check results for 30 seconds
+let connectivityCache: {
+  internet: boolean;
+  llm: boolean | null; // null = no provider configured
+  checkedAt: number;
+} | null = null;
+
+const CONNECTIVITY_CACHE_TTL_MS = 30_000;
+
+async function checkConnectivity(): Promise<{ internet: boolean; llm: boolean | null }> {
+  const now = Date.now();
+  
+  // Return cached result if still valid
+  if (connectivityCache && (now - connectivityCache.checkedAt) < CONNECTIVITY_CACHE_TTL_MS) {
+    return { internet: connectivityCache.internet, llm: connectivityCache.llm };
+  }
+
+  let internet = false;
+  let llm: boolean | null = null; // null means no provider configured
+
+  // Check internet connectivity via DNS/simple fetch
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    
+    // Use a reliable public endpoint for internet check
+    const response = await fetch("https://dns.google/resolve?name=example.com&type=A", {
+      method: "GET",
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+    internet = response.ok;
+  } catch {
+    internet = false;
+  }
+
+  // Check LLM provider connectivity if internet is available
+  if (internet) {
+    try {
+      const config = await getServerConfig();
+      const provider = config?.inferenceProvider;
+      
+      if (provider?.baseUrl) {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 5000);
+        
+        // Normalize base URL - just get the host part for a simple HEAD request
+        let baseUrl = provider.baseUrl.replace(/\/$/, "");
+        
+        // Try a simple HEAD request to the base URL (not /v1/models which may not exist)
+        const response = await fetch(baseUrl, {
+          method: "HEAD",
+          signal: controller.signal,
+        });
+        clearTimeout(timeoutId);
+        // Consider reachable if we get any response (even 4xx means server is up)
+        llm = response.status < 500;
+      } else {
+        // No provider configured - that's fine, just means LLM not set up
+        llm = null;
+      }
+    } catch (err) {
+      // Network error - provider is configured but unreachable
+      console.log("[health] LLM connectivity check failed:", err instanceof Error ? err.message : String(err));
+      llm = false;
+    }
+  }
+
+  // Update cache
+  connectivityCache = { internet, llm, checkedAt: now };
+
+  return { internet, llm };
+}
+
 export async function healthHandler(_req: Request, res: Response) {
+  const connectivity = await checkConnectivity();
+  
   res.json({
     status: "ok",
     timestamp: new Date().toISOString(),
+    connectivity: {
+      internet: connectivity.internet,
+      llm: connectivity.llm,
+    },
   });
 }

--- a/frontend/src/components/ConnectivityStatus.tsx
+++ b/frontend/src/components/ConnectivityStatus.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from "react";
+import { WifiOff, AlertTriangle } from "lucide-react";
+
+interface ConnectivityState {
+  internet: boolean;
+  llm: boolean | null; // null = no provider configured
+  checkedAt: number;
+}
+
+const POLL_INTERVAL_MS = 30_000; // 30 seconds
+
+export function ConnectivityStatus() {
+  const [connectivity, setConnectivity] = useState<ConnectivityState | null>(null);
+  const [browserOnline, setBrowserOnline] = useState(navigator.onLine);
+
+  // Listen for browser online/offline events
+  useEffect(() => {
+    const handleOnline = () => setBrowserOnline(true);
+    const handleOffline = () => setBrowserOnline(false);
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  // Poll the health endpoint for server-side connectivity status
+  useEffect(() => {
+    const checkConnectivity = async () => {
+      try {
+        const response = await fetch("/health");
+        if (response.ok) {
+          const data = await response.json();
+          setConnectivity({
+            internet: data.connectivity?.internet ?? true,
+            llm: data.connectivity?.llm ?? true,
+            checkedAt: Date.now(),
+          });
+        }
+      } catch {
+        // Server unreachable - browser might be offline
+        setConnectivity({
+          internet: false,
+          llm: false,
+          checkedAt: Date.now(),
+        });
+      }
+    };
+
+    // Initial check
+    checkConnectivity();
+
+    // Poll periodically
+    const interval = setInterval(checkConnectivity, POLL_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  // Don't show anything if everything is fine
+  // llm === null means no provider configured (that's fine)
+  // llm === true means provider is reachable
+  if (browserOnline && connectivity?.internet && (connectivity?.llm === null || connectivity?.llm === true)) {
+    return null;
+  }
+
+  // Browser is offline
+  if (!browserOnline) {
+    return (
+      <div className="bg-red-500/10 border-b border-red-500/20 px-4 py-2 flex items-center justify-center gap-2 text-red-600 dark:text-red-400 text-sm">
+        <WifiOff className="h-4 w-4" />
+        <span>You are offline. Some features may not work.</span>
+      </div>
+    );
+  }
+
+  // Server has no internet
+  if (connectivity && !connectivity.internet) {
+    return (
+      <div className="bg-yellow-500/10 border-b border-yellow-500/20 px-4 py-2 flex items-center justify-center gap-2 text-yellow-600 dark:text-yellow-400 text-sm">
+        <WifiOff className="h-4 w-4" />
+        <span>Server is offline. Jobs requiring internet will fail.</span>
+      </div>
+    );
+  }
+
+  // Server has internet but LLM provider is unreachable (llm === false, not null)
+  if (connectivity && connectivity.internet && connectivity.llm === false) {
+    return (
+      <div className="bg-yellow-500/10 border-b border-yellow-500/20 px-4 py-2 flex items-center justify-center gap-2 text-yellow-600 dark:text-yellow-400 text-sm">
+        <AlertTriangle className="h-4 w-4" />
+        <span>LLM provider is unreachable. AI features may not work.</span>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button.tsx";
 import { useJobsListener } from "@/hooks/useJobsListener";
 import { Badge } from "@/components/ui/badge";
 import { NotificationCenter } from "@/components/NotificationCenter";
+import { ConnectivityStatus } from "@/components/ConnectivityStatus";
 
 const Layout = () => {
   useTheme();
@@ -25,6 +26,7 @@ const Layout = () => {
   return (
     <TooltipProvider>
       <div className="min-h-screen bg-background">
+        <ConnectivityStatus />
         <nav className="border-b">
           <div className="mx-auto px-4 md:container">
             <div className="flex h-16 items-center justify-between">

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, Ban } from "lucide-react";
+import { ArrowLeft, Ban, RefreshCw, WifiOff } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { JobInfo, JobLogEntry, JobAccessLogEntry } from "@/types/jobs";
 
@@ -178,9 +178,31 @@ export default function JobDetailPage() {
         },
     });
 
+    const retryJobMutation = useMutation({
+        mutationFn: async () => {
+            if (!id) return;
+            return await api.callResource("jobs", {
+                action: "retry",
+                id: id,
+            });
+        },
+        onSuccess: (data: any) => {
+            queryClient.invalidateQueries({ queryKey: ["job", id] });
+            queryClient.invalidateQueries({ queryKey: ["jobs", "all"] });
+            // Navigate to the new job if created
+            if (data?.newJobId) {
+                window.location.href = `/jobs/${data.newJobId}`;
+            }
+        },
+    });
+
     const handleCancel = async () => {
         if (!confirm("Are you sure you want to cancel this job?")) return;
         cancelJobMutation.mutate();
+    };
+
+    const handleRetry = async () => {
+        retryJobMutation.mutate();
     };
 
     const job = cachedJob || fetchedJob;
@@ -254,17 +276,30 @@ export default function JobDetailPage() {
                         </p>
                     </div>
                 </div>
-                {["active", "waiting", "delayed"].includes(job.state) && (
-                    <Button 
-                        variant="destructive" 
-                        size="sm"
-                        onClick={handleCancel}
-                        disabled={cancelJobMutation.isPending}
-                    >
-                        <Ban className="h-4 w-4 mr-2" />
-                        Cancel Job
-                    </Button>
-                )}
+                <div className="flex gap-2">
+                    {["failed", "cancelled"].includes(job.state) && (
+                        <Button 
+                            variant="outline" 
+                            size="sm"
+                            onClick={handleRetry}
+                            disabled={retryJobMutation.isPending}
+                        >
+                            <RefreshCw className={`h-4 w-4 mr-2 ${retryJobMutation.isPending ? 'animate-spin' : ''}`} />
+                            Retry Job
+                        </Button>
+                    )}
+                    {["active", "waiting", "delayed"].includes(job.state) && (
+                        <Button 
+                            variant="destructive" 
+                            size="sm"
+                            onClick={handleCancel}
+                            disabled={cancelJobMutation.isPending}
+                        >
+                            <Ban className="h-4 w-4 mr-2" />
+                            Cancel Job
+                        </Button>
+                    )}
+                </div>
             </div>
 
             <div className="grid gap-6 md:grid-cols-2">
@@ -318,8 +353,16 @@ export default function JobDetailPage() {
                             )}
 
                         {job.failedReason && (
-                            <div className="text-sm text-red-500">{job.failedReason}</div>
-
+                            <div>
+                                <div className="text-sm text-muted-foreground mb-1">Failed Reason</div>
+                                {job.failedType === "offline" && (
+                                    <div className="flex items-center gap-2 mb-2 text-yellow-600">
+                                        <WifiOff className="h-4 w-4" />
+                                        <span className="text-sm font-medium">Network/Offline Error</span>
+                                    </div>
+                                )}
+                                <div className="text-sm text-red-500">{job.failedReason}</div>
+                            </div>
                         )}
 
 <div>

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, Ban, RefreshCw, WifiOff } from "lucide-react";
+import { ArrowLeft, Ban, RefreshCw, WifiOff, Server } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { JobInfo, JobLogEntry, JobAccessLogEntry } from "@/types/jobs";
 
@@ -359,6 +359,12 @@ export default function JobDetailPage() {
                                     <div className="flex items-center gap-2 mb-2 text-yellow-600">
                                         <WifiOff className="h-4 w-4" />
                                         <span className="text-sm font-medium">Network/Offline Error</span>
+                                    </div>
+                                )}
+                                {job.failedType === "internal" && (
+                                    <div className="flex items-center gap-2 mb-2 text-orange-600">
+                                        <Server className="h-4 w-4" />
+                                        <span className="text-sm font-medium">Internal Service Error</span>
                                     </div>
                                 )}
                                 <div className="text-sm text-red-500">{job.failedReason}</div>

--- a/frontend/src/pages/JobsPage.tsx
+++ b/frontend/src/pages/JobsPage.tsx
@@ -17,7 +17,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { RefreshCw, Trash2, Play, Search, ChevronDown, ArrowUpDown, ArrowUp, ArrowDown, PlayCircle, PauseCircle, Activity, Clock, AlertCircle, CheckCircle, WifiOff } from "lucide-react";
+import { RefreshCw, Trash2, Play, Search, ChevronDown, ArrowUpDown, ArrowUp, ArrowDown, PlayCircle, PauseCircle, Activity, Clock, AlertCircle, CheckCircle, WifiOff, Server } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -925,6 +925,11 @@ export default function JobsPage() {
                         {job.failedType === "offline" && (
                           <span title="Network/Offline Error">
                             <WifiOff className="h-3.5 w-3.5 text-yellow-500" />
+                          </span>
+                        )}
+                        {job.failedType === "internal" && (
+                          <span title="Internal Service Error">
+                            <Server className="h-3.5 w-3.5 text-orange-500" />
                           </span>
                         )}
                       </Link>

--- a/frontend/src/pages/JobsPage.tsx
+++ b/frontend/src/pages/JobsPage.tsx
@@ -17,7 +17,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { RefreshCw, Trash2, Play, Search, ChevronDown, ArrowUpDown, ArrowUp, ArrowDown, PlayCircle, PauseCircle, Activity, Clock, AlertCircle, CheckCircle } from "lucide-react";
+import { RefreshCw, Trash2, Play, Search, ChevronDown, ArrowUpDown, ArrowUp, ArrowDown, PlayCircle, PauseCircle, Activity, Clock, AlertCircle, CheckCircle, WifiOff } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -146,6 +146,29 @@ export default function JobsPage() {
     },
   });
 
+  const retryAllOfflineMutation = useMutation({
+    mutationFn: async () => {
+      return await api.callResource("jobs", {
+        action: "retry_all_offline",
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["jobs", "all"] });
+    },
+  });
+
+  const retryJobMutation = useMutation({
+    mutationFn: async (jobId: string) => {
+      return await api.callResource("jobs", {
+        action: "retry",
+        id: jobId,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["jobs", "all"] });
+    },
+  });
+
   const allTypes = useMemo(() => Object.keys(schemas || {}), [schemas]);
 
   const allPaused = useMemo(() => {
@@ -160,11 +183,14 @@ export default function JobsPage() {
 
   // Job counts by status
   const jobCounts = useMemo(() => {
-    const counts = { active: 0, waiting: 0, failed: 0, completed: 0, delayed: 0, total: 0 };
+    const counts = { active: 0, waiting: 0, failed: 0, completed: 0, delayed: 0, total: 0, offlineFailures: 0 };
     for (const job of jobs) {
       counts.total++;
       if (job.state in counts) {
         counts[job.state as keyof typeof counts]++;
+      }
+      if (job.state === "failed" && job.failedType === "offline") {
+        counts.offlineFailures++;
       }
     }
     return counts;
@@ -679,6 +705,21 @@ export default function JobsPage() {
           <AlertCircle className="h-3.5 w-3.5 mr-1" />
           Errors ({jobCounts.failed})
         </Button>
+        {jobCounts.offlineFailures > 0 && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => retryAllOfflineMutation.mutate()}
+            disabled={retryAllOfflineMutation.isPending}
+            className="text-yellow-600 hover:text-yellow-700 border-yellow-500/30"
+          >
+            <WifiOff className="h-3.5 w-3.5 mr-1" />
+            Retry {jobCounts.offlineFailures} Offline
+            {retryAllOfflineMutation.isPending && (
+              <RefreshCw className="h-3 w-3 ml-1 animate-spin" />
+            )}
+          </Button>
+        )}
         <Button
           variant={quickFilter === "completed" ? "default" : "outline"}
           size="sm"
@@ -848,18 +889,19 @@ export default function JobsPage() {
                   </div>
                 </TableHead>
                 <TableHead>Progress</TableHead>
+                <TableHead className="w-[80px]">Actions</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {isLoading ? (
                 <TableRow>
-                  <TableCell colSpan={7} className="text-center py-8">
+                  <TableCell colSpan={8} className="text-center py-8">
                     Loading jobs...
                   </TableCell>
                 </TableRow>
               ) : filteredJobs.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={7} className="text-center py-8">
+                  <TableCell colSpan={8} className="text-center py-8">
                     No jobs found
                   </TableCell>
                 </TableRow>
@@ -872,6 +914,7 @@ export default function JobsPage() {
                     <TableCell>
                       <Link
                         to={`/jobs/${job.id}`}
+                        className="flex items-center gap-1.5"
                       >
                         <Badge
                           variant="secondary"
@@ -879,6 +922,11 @@ export default function JobsPage() {
                         >
                           {job.state}
                         </Badge>
+                        {job.failedType === "offline" && (
+                          <span title="Network/Offline Error">
+                            <WifiOff className="h-3.5 w-3.5 text-yellow-500" />
+                          </span>
+                        )}
                       </Link>
                     </TableCell>
                     <TableCell className="font-medium">{job.type}</TableCell>
@@ -927,6 +975,19 @@ export default function JobsPage() {
                         </div>
                       ) : (
                         "-"
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {["failed", "cancelled"].includes(job.state) && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => retryJobMutation.mutate(job.id)}
+                          disabled={retryJobMutation.isPending}
+                          className="h-7 px-2"
+                        >
+                          <RefreshCw className={`h-3.5 w-3.5 ${retryJobMutation.isPending ? 'animate-spin' : ''}`} />
+                        </Button>
                       )}
                     </TableCell>
                   </TableRow>

--- a/frontend/src/types/jobs.ts
+++ b/frontend/src/types/jobs.ts
@@ -15,7 +15,7 @@ export type JobInfo = {
   finishedOn?: number;
   processedOn?: number;
   failedReason?: string;
-  failedType?: "offline";
+  failedType?: "offline" | "internal";
   attemptsMade?: number;
 };
 

--- a/frontend/src/types/jobs.ts
+++ b/frontend/src/types/jobs.ts
@@ -15,6 +15,7 @@ export type JobInfo = {
   finishedOn?: number;
   processedOn?: number;
   failedReason?: string;
+  failedType?: "offline";
   attemptsMade?: number;
 };
 

--- a/myceliasdk/resources.ts
+++ b/myceliasdk/resources.ts
@@ -1,5 +1,33 @@
 import { EJSON } from "bson";
 
+const MAX_RETRIES = 3;
+const INITIAL_DELAY_MS = 500;
+
+/**
+ * Fetch with retry for transient connection errors (e.g., backend restarting)
+ */
+async function fetchWithRetry(url: string, options: RequestInit, retries = MAX_RETRIES): Promise<Response> {
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        try {
+            return await fetch(url, options);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            const isRetryable = 
+                message.toLowerCase().includes("connection refused") ||
+                message.includes("ECONNREFUSED") ||
+                message.includes("os error 111");
+
+            if (!isRetryable || attempt === retries) {
+                throw err;
+            }
+
+            const delay = INITIAL_DELAY_MS * Math.pow(2, attempt);
+            console.log(`[SDK] Connection failed, retrying in ${delay}ms (attempt ${attempt + 1}/${retries}): ${message}`);
+            await new Promise(r => setTimeout(r, delay));
+        }
+    }
+    throw new Error("Should not reach here");
+}
 
 export async function callResource<Input, Output>(code: string, input: Input, {
     jwt,
@@ -8,7 +36,7 @@ export async function callResource<Input, Output>(code: string, input: Input, {
     jwt: string;
     myceliaUrl: string;
 }): Promise<Output> {
-    const response = await fetch(`${myceliaUrl}/api/resource/${code}`, {
+    const response = await fetchWithRetry(`${myceliaUrl}/api/resource/${code}`, {
         method: "POST",
         headers: { "Content-Type": "application/json", "Authorization": `Bearer ${jwt}` },
         body: EJSON.stringify(EJSON.serialize(input)),


### PR DESCRIPTION
- Implemented `isNetworkError` function to identify network-related job failures.

- Added `retry` and `retry_all_offline` actions in the JobsResource for re-enqueuing failed jobs.

- Updated JobDetailPage and JobsPage to include retry buttons for failed jobs.

- Introduced ConnectivityStatus component to display internet and LLM provider connectivity status.

- Enhanced health check endpoint to cache connectivity results and return detailed status.

- Updated job types to include `failedType` for better error categorization.