### PR TITLE
Fix worker default overrides not being applied to jobs

### DIFF
--- a/backend/app/lib/jobs/processor.ts
+++ b/backend/app/lib/jobs/processor.ts
@@ -12,11 +12,12 @@ export async function processJob(job: Job<JobData>): Promise<JobResult> {
   const jobType = job.data.type;
   const capability = jobRegistry.getOrThrow(jobType);
 
-  // Apply default overrides from workers collection
-  // These overrides are applied ONLY if the job data doesn't already have the field
+  // Apply default overrides from workers collection (fallback for legacy jobs)
+  // NOTE: Worker defaults are now primarily applied at enqueue time in queue.ts
+  // This fallback handles jobs enqueued before that change was deployed
   const { workerDiscovery } = await import("./worker-discovery.ts");
   const defaultOverrides = await workerDiscovery.getDefaultOverrides(jobType);
-  
+
   const mergedJobData = { ...job.data };
   if (defaultOverrides) {
     // Only apply overrides for fields not already in job data

--- a/backend/app/lib/jobs/queue.ts
+++ b/backend/app/lib/jobs/queue.ts
@@ -53,7 +53,24 @@ export async function enqueueJob(
   authOverride?: Auth,
 ): Promise<Job<JobData>> {
   const jobId = options?.jobId || new ObjectId().toString();
-  const parsedData = jobRegistry.validateJobData(data);
+
+  // Apply worker default overrides BEFORE schema validation
+  // This ensures worker defaults take precedence over schema defaults
+  // but explicit job data values still take precedence over worker defaults
+  let mergedData = { ...data };
+  if (data.type) {
+    const { workerDiscovery } = await import("./worker-discovery.ts");
+    const defaultOverrides = await workerDiscovery.getDefaultOverrides(data.type);
+    if (defaultOverrides) {
+      for (const [key, value] of Object.entries(defaultOverrides)) {
+        if (!(key in mergedData) || mergedData[key] === undefined) {
+          mergedData[key] = value;
+        }
+      }
+    }
+  }
+
+  const parsedData = jobRegistry.validateJobData(mergedData);
 
   if (!parsedData.type) {
     throw new Error(`Job data is missing 'type' field after validation for job ID: ${jobId}. Check if the schema for this job type includes the 'type' field.`);


### PR DESCRIPTION
## Summary
- Fixed bug where worker default settings (model, prompt, etc.) configured in Settings > Workers were being ignored
- Root cause: Schema validation applied defaults at enqueue time, making worker defaults ineffective since the processor only applied overrides for missing fields

## Changes
- **queue.ts**: Apply worker default overrides BEFORE schema validation at enqueue time
- **processor.ts**: Updated comments to explain the fallback behavior for legacy jobs

## Priority Order (Now Correct)
1. **Explicit job data** (highest) - values passed when enqueuing
2. **Worker defaults** - from Settings > Workers configuration
3. **Schema defaults** (lowest) - hardcoded in worker code
