### PR TITLE
Enhance Object Detail Page with improved autosave, audio player, and UI fixes

### DIFF
--- a/frontend/src/components/MetadataDisplay.tsx
+++ b/frontend/src/components/MetadataDisplay.tsx
@@ -54,14 +54,7 @@ function formatDuration(startDate: Date | string, endDate?: Date | string | null
 
 function formatDateTime(date: Date | string): string {
   const d = typeof date === "string" ? new Date(date) : date;
-  return d.toLocaleString(undefined, {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
+  return formatTime(d, "gregorian-local-natural");
 }
 
 function getObjectType(object: Object): {

--- a/frontend/src/components/MetadataDisplay.tsx
+++ b/frontend/src/components/MetadataDisplay.tsx
@@ -26,6 +26,8 @@ interface MetadataDisplayProps {
   hideTimeInfo?: boolean;
   /** Callback when Edit button is clicked for time ranges */
   onEditTimeRanges?: () => void;
+  /** Use compact layout with smaller text and spacing */
+  compact?: boolean;
 }
 
 function formatDuration(startDate: Date | string, endDate?: Date | string | null): string {
@@ -70,7 +72,7 @@ function getObjectType(object: Object): {
   return { type: "Object", icon: Package, color: "bg-gray-100 text-gray-800 border-gray-200" };
 }
 
-export function MetadataDisplay({ object, hideObjectType, hideTimeInfo, onEditTimeRanges }: MetadataDisplayProps) {
+export function MetadataDisplay({ object, hideObjectType, hideTimeInfo, onEditTimeRanges, compact = false }: MetadataDisplayProps) {
   const extractedWith = object?.metadata?.extractedWith;
   const timeRanges = object?.timeRanges;
   const hasTimeRange = timeRanges && timeRanges.length > 0;

--- a/frontend/src/components/MetadataDisplay.tsx
+++ b/frontend/src/components/MetadataDisplay.tsx
@@ -18,6 +18,10 @@ import {
 
 interface MetadataDisplayProps {
   object: Object;
+  /** Hide the object type card when already displayed elsewhere */
+  hideObjectType?: boolean;
+  /** Hide time information when player is already visible */
+  hideTimeInfo?: boolean;
 }
 
 function formatDuration(startDate: Date | string, endDate?: Date | string | null): string {
@@ -69,7 +73,7 @@ function getObjectType(object: Object): {
   return { type: "Object", icon: Package, color: "bg-gray-100 text-gray-800 border-gray-200" };
 }
 
-export function MetadataDisplay({ object }: MetadataDisplayProps) {
+export function MetadataDisplay({ object, hideObjectType, hideTimeInfo }: MetadataDisplayProps) {
   const extractedWith = object?.metadata?.extractedWith;
   const timeRanges = object?.timeRanges;
   const hasTimeRange = timeRanges && timeRanges.length > 0;
@@ -79,19 +83,21 @@ export function MetadataDisplay({ object }: MetadataDisplayProps) {
 
   return (
     <div className="space-y-4">
-      {/* Object Type Badge */}
-      <Card className="p-4 bg-muted/50">
-        <h3 className="text-sm font-semibold text-muted-foreground mb-3">
-          Object Type
-        </h3>
-        <div className={`inline-flex items-center gap-2 px-3 py-2 rounded-lg border ${typeInfo.color}`}>
-          <TypeIcon className="w-4 h-4" />
-          <span className="font-medium">{typeInfo.type}</span>
-        </div>
-      </Card>
+      {/* Object Type Badge - hidden when displayed elsewhere */}
+      {!hideObjectType && (
+        <Card className="p-4 bg-muted/50">
+          <h3 className="text-sm font-semibold text-muted-foreground mb-3">
+            Object Type
+          </h3>
+          <div className={`inline-flex items-center gap-2 px-3 py-2 rounded-lg border ${typeInfo.color}`}>
+            <TypeIcon className="w-4 h-4" />
+            <span className="font-medium">{typeInfo.type}</span>
+          </div>
+        </Card>
+      )}
 
       {/* Time Information - prominent display for conversations/events */}
-      {hasTimeRange && firstRange && (
+      {!hideTimeInfo && hasTimeRange && firstRange && (
         <Card className="p-4 bg-muted/50">
           <h3 className="text-sm font-semibold text-muted-foreground mb-3">
             Time Information

--- a/frontend/src/components/MetadataDisplay.tsx
+++ b/frontend/src/components/MetadataDisplay.tsx
@@ -24,6 +24,8 @@ interface MetadataDisplayProps {
   hideObjectType?: boolean;
   /** Hide time information when player is already visible */
   hideTimeInfo?: boolean;
+  /** Hide metadata (created, updated, version) when displayed elsewhere */
+  hideMetadata?: boolean;
   /** Callback when Edit button is clicked for time ranges */
   onEditTimeRanges?: () => void;
   /** Use compact layout with smaller text and spacing */
@@ -72,7 +74,7 @@ function getObjectType(object: Object): {
   return { type: "Object", icon: Package, color: "bg-gray-100 text-gray-800 border-gray-200" };
 }
 
-export function MetadataDisplay({ object, hideObjectType, hideTimeInfo, onEditTimeRanges, compact = false }: MetadataDisplayProps) {
+export function MetadataDisplay({ object, hideObjectType, hideTimeInfo, hideMetadata, onEditTimeRanges, compact = false }: MetadataDisplayProps) {
   const extractedWith = object?.metadata?.extractedWith;
   const timeRanges = object?.timeRanges;
   const hasTimeRange = timeRanges && timeRanges.length > 0;
@@ -185,31 +187,33 @@ export function MetadataDisplay({ object, hideObjectType, hideTimeInfo, onEditTi
       )}
 
       {/* General Metadata */}
-      <Card className="p-4 bg-muted/50">
-        <h3 className="text-sm font-semibold text-muted-foreground mb-3">
-          Metadata
-        </h3>
-        <dl className="space-y-3 text-sm">
-          <div className="flex justify-between items-center">
-            <dt className="text-muted-foreground">Created:</dt>
-            <dd className="text-foreground">
-              {formatTime(new Date(object.createdAt))}
-            </dd>
-          </div>
-          <div className="flex justify-between items-center">
-            <dt className="text-muted-foreground">Updated:</dt>
-            <dd className="text-foreground">
-              {formatTime(new Date(object.updatedAt))}
-            </dd>
-          </div>
-          <div className="flex justify-between items-center">
-            <dt className="text-muted-foreground">Version:</dt>
-            <dd className="text-foreground">
-              {(object?.version || 0 ) as number}
-            </dd>
-          </div>
-        </dl>
-      </Card>
+      {!hideMetadata && (
+        <Card className="p-4 bg-muted/50">
+          <h3 className="text-sm font-semibold text-muted-foreground mb-3">
+            Metadata
+          </h3>
+          <dl className="space-y-3 text-sm">
+            <div className="flex justify-between items-center">
+              <dt className="text-muted-foreground">Created:</dt>
+              <dd className="text-foreground">
+                {formatTime(new Date(object.createdAt))}
+              </dd>
+            </div>
+            <div className="flex justify-between items-center">
+              <dt className="text-muted-foreground">Updated:</dt>
+              <dd className="text-foreground">
+                {formatTime(new Date(object.updatedAt))}
+              </dd>
+            </div>
+            <div className="flex justify-between items-center">
+              <dt className="text-muted-foreground">Version:</dt>
+              <dd className="text-foreground">
+                {(object?.version || 0 ) as number}
+              </dd>
+            </div>
+          </dl>
+        </Card>
+      )}
 
       {extractedWith && (
         <Card className="p-4 bg-muted/50">

--- a/frontend/src/components/MetadataDisplay.tsx
+++ b/frontend/src/components/MetadataDisplay.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import type { Object } from "@/types/objects";
 import { formatTime } from "@/lib/formatTime";
 import {
@@ -14,6 +15,7 @@ import {
   User,
   Users,
   LineChart,
+  Pencil,
 } from "lucide-react";
 
 interface MetadataDisplayProps {
@@ -22,6 +24,8 @@ interface MetadataDisplayProps {
   hideObjectType?: boolean;
   /** Hide time information when player is already visible */
   hideTimeInfo?: boolean;
+  /** Callback when Edit button is clicked for time ranges */
+  onEditTimeRanges?: () => void;
 }
 
 function formatDuration(startDate: Date | string, endDate?: Date | string | null): string {
@@ -73,7 +77,7 @@ function getObjectType(object: Object): {
   return { type: "Object", icon: Package, color: "bg-gray-100 text-gray-800 border-gray-200" };
 }
 
-export function MetadataDisplay({ object, hideObjectType, hideTimeInfo }: MetadataDisplayProps) {
+export function MetadataDisplay({ object, hideObjectType, hideTimeInfo, onEditTimeRanges }: MetadataDisplayProps) {
   const extractedWith = object?.metadata?.extractedWith;
   const timeRanges = object?.timeRanges;
   const hasTimeRange = timeRanges && timeRanges.length > 0;
@@ -99,9 +103,22 @@ export function MetadataDisplay({ object, hideObjectType, hideTimeInfo }: Metada
       {/* Time Information - prominent display for conversations/events */}
       {!hideTimeInfo && hasTimeRange && firstRange && (
         <Card className="p-4 bg-muted/50">
-          <h3 className="text-sm font-semibold text-muted-foreground mb-3">
-            Time Information
-          </h3>
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-sm font-semibold text-muted-foreground">
+              Time Information
+            </h3>
+            {onEditTimeRanges && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2"
+                onClick={onEditTimeRanges}
+              >
+                <Pencil className="w-3.5 h-3.5 mr-1" />
+                Edit
+              </Button>
+            )}
+          </div>
           <dl className="space-y-3 text-sm">
             <div className="flex items-start gap-3">
               <CalendarClock className="w-4 h-4 text-muted-foreground mt-0.5" />

--- a/frontend/src/components/ObjectAudioPlayer.tsx
+++ b/frontend/src/components/ObjectAudioPlayer.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useCallback } from "react";
-import { Volume2 } from "lucide-react";
+import { Link } from "react-router-dom";
+import { Volume2, Calendar } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
 import {
   Select,
@@ -186,6 +188,22 @@ export function ObjectAudioPlayer({ timeRange }: ObjectAudioPlayerProps) {
             className="flex-1"
           />
         </div>
+
+        {/* Divider */}
+        <div className="h-8 w-px bg-border hidden sm:block" />
+
+        {/* View in Timeline button */}
+        <Button
+          variant="outline"
+          size="sm"
+          asChild
+          className="h-8 text-xs"
+        >
+          <Link to={`/timeline?date=${(currentDate || startDate).getTime()}`}>
+            <Calendar className="w-3.5 h-3.5 mr-1.5" />
+            Timeline
+          </Link>
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/components/ObjectAudioPlayer.tsx
+++ b/frontend/src/components/ObjectAudioPlayer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useCallback } from "react";
 import { Volume2 } from "lucide-react";
 import { Slider } from "@/components/ui/slider";
 import {
@@ -30,7 +30,7 @@ const SPEED_OPTIONS = [
 ];
 
 export function ObjectAudioPlayer({ timeRange }: ObjectAudioPlayerProps) {
-  const { currentDate, resetDate } = useAudioPlayer();
+  const { currentDate, resetDate, isPlaying, setIsPlaying } = useAudioPlayer();
   const { volume, setVolume, playbackRate, setPlaybackRate, timeFormat } = useSettingsStore();
   const prevStartTimeRef = useRef<number | null>(null);
 
@@ -52,6 +52,17 @@ export function ObjectAudioPlayer({ timeRange }: ObjectAudioPlayerProps) {
       prevStartTimeRef.current = startTime;
     }
   }, [startDate, resetDate]);
+
+  // Stop playback when currentDate exceeds endDate
+  useEffect(() => {
+    if (!isPlaying || !currentDate || !endDate) return;
+    
+    if (currentDate.getTime() >= endDate.getTime()) {
+      setIsPlaying(false);
+      // Reset to end position so progress bar shows 100%
+      resetDate(endDate);
+    }
+  }, [currentDate, endDate, isPlaying, setIsPlaying, resetDate]);
 
   const handleVolumeChange = (value: number[]) => {
     setVolume(value[0]);

--- a/frontend/src/components/ObjectAudioPlayer.tsx
+++ b/frontend/src/components/ObjectAudioPlayer.tsx
@@ -199,9 +199,9 @@ export function ObjectAudioPlayer({ timeRange }: ObjectAudioPlayerProps) {
           asChild
           className="h-8 text-xs"
         >
-          <Link to={`/timeline?date=${(currentDate || startDate).getTime()}`}>
+          <Link to={`/timeline?start=${startDate.getTime()}${endDate ? `&end=${endDate.getTime()}` : ''}`}>
             <Calendar className="w-3.5 h-3.5 mr-1.5" />
-            Timeline
+            View in Timeline
           </Link>
         </Button>
       </div>

--- a/frontend/src/components/ObjectForm.tsx
+++ b/frontend/src/components/ObjectForm.tsx
@@ -607,53 +607,53 @@ export function ObjectForm(
       {/* Object Type Toggle Buttons */}
       <div className={compact ? "space-y-1" : "space-y-2"}>
         <Label className={`text-muted-foreground ${compact ? 'text-xs' : 'text-sm'}`}>Object Type</Label>
-        <div className={`flex flex-wrap ${compact ? 'gap-1' : 'gap-2'}`}>
+        <div className={`flex flex-wrap ${compact ? 'gap-1.5' : 'gap-2'}`}>
           <button
             type="button"
             onClick={() => updateField("isPerson", !object.isPerson)}
             className={`
-              flex items-center rounded-lg border transition-all
-              ${compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-2 px-3 py-2 text-sm'}
+              flex items-center rounded-lg border-2 transition-all font-medium
+              ${compact ? 'gap-1.5 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
               ${object.isPerson
-                ? "bg-blue-100 text-blue-800 border-blue-200"
-                : "bg-background border-border hover:bg-muted"
+                ? "bg-blue-500 text-white border-blue-600 shadow-md"
+                : "bg-background border-border hover:bg-blue-50 hover:border-blue-300"
               }
             `}
           >
-            <User className={compact ? "w-3 h-3" : "w-4 h-4"} />
-            <span className={compact ? "" : "font-medium"}>{compact ? "Person" : "Person"}</span>
+            <User className={compact ? "w-3.5 h-3.5" : "w-4 h-4"} />
+            <span>Person</span>
           </button>
 
           <button
             type="button"
             onClick={() => updateField("isEvent", !object.isEvent)}
             className={`
-              flex items-center rounded-lg border transition-all
-              ${compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-2 px-3 py-2 text-sm'}
+              flex items-center rounded-lg border-2 transition-all font-medium
+              ${compact ? 'gap-1.5 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
               ${object.isEvent
-                ? "bg-green-100 text-green-800 border-green-200"
-                : "bg-background border-border hover:bg-muted"
+                ? "bg-green-500 text-white border-green-600 shadow-md"
+                : "bg-background border-border hover:bg-green-50 hover:border-green-300"
               }
             `}
           >
-            <Calendar className={compact ? "w-3 h-3" : "w-4 h-4"} />
-            <span className={compact ? "" : "font-medium"}>{compact ? "Event" : "Event"}</span>
+            <Calendar className={compact ? "w-3.5 h-3.5" : "w-4 h-4"} />
+            <span>Event</span>
           </button>
 
           <button
             type="button"
             onClick={() => updateField("isConversation", !object.isConversation)}
             className={`
-              flex items-center rounded-lg border transition-all
-              ${compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-2 px-3 py-2 text-sm'}
+              flex items-center rounded-lg border-2 transition-all font-medium
+              ${compact ? 'gap-1.5 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
               ${object.isConversation
-                ? "bg-cyan-100 text-cyan-800 border-cyan-200"
-                : "bg-background border-border hover:bg-muted"
+                ? "bg-cyan-500 text-white border-cyan-600 shadow-md"
+                : "bg-background border-border hover:bg-cyan-50 hover:border-cyan-300"
               }
             `}
           >
-            <MessageSquare className={compact ? "w-3 h-3" : "w-4 h-4"} />
-            <span className={compact ? "" : "font-medium"}>{compact ? "Conv" : "Conversation"}</span>
+            <MessageSquare className={compact ? "w-3.5 h-3.5" : "w-4 h-4"} />
+            <span>{compact ? "Conv" : "Conversation"}</span>
           </button>
 
           <button
@@ -673,16 +673,16 @@ export function ObjectForm(
               }
             }}
             className={`
-              flex items-center rounded-lg border transition-all
-              ${compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-2 px-3 py-2 text-sm'}
+              flex items-center rounded-lg border-2 transition-all font-medium
+              ${compact ? 'gap-1.5 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
               ${object.isRelationship && !object.isPromise
-                ? "bg-purple-100 text-purple-800 border-purple-200"
-                : "bg-background border-border hover:bg-muted"
+                ? "bg-purple-500 text-white border-purple-600 shadow-md"
+                : "bg-background border-border hover:bg-purple-50 hover:border-purple-300"
               }
             `}
           >
-            <Users className={compact ? "w-3 h-3" : "w-4 h-4"} />
-            <span className={compact ? "" : "font-medium"}>{compact ? "Rel" : "Relationship"}</span>
+            <Users className={compact ? "w-3.5 h-3.5" : "w-4 h-4"} />
+            <span>{compact ? "Rel" : "Relationship"}</span>
           </button>
 
           <button
@@ -700,16 +700,16 @@ export function ObjectForm(
               }
             }}
             className={`
-              flex items-center rounded-lg border transition-all
-              ${compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-2 px-3 py-2 text-sm'}
+              flex items-center rounded-lg border-2 transition-all font-medium
+              ${compact ? 'gap-1.5 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
               ${object.isPromise
-                ? "bg-orange-100 text-orange-800 border-orange-200"
-                : "bg-background border-border hover:bg-muted"
+                ? "bg-orange-500 text-white border-orange-600 shadow-md"
+                : "bg-background border-border hover:bg-orange-50 hover:border-orange-300"
               }
             `}
           >
-            <Handshake className={compact ? "w-3 h-3" : "w-4 h-4"} />
-            <span className={compact ? "" : "font-medium"}>{compact ? "Promise" : "Promise"}</span>
+            <Handshake className={compact ? "w-3.5 h-3.5" : "w-4 h-4"} />
+            <span>Promise</span>
           </button>
         </div>
       </div>

--- a/frontend/src/components/ObjectForm.tsx
+++ b/frontend/src/components/ObjectForm.tsx
@@ -6,7 +6,6 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
-import { DateTimePicker } from "@/components/ui/datetime-picker";
 import {
   ArrowRight,
   Calendar,
@@ -42,6 +41,7 @@ import {
 } from "@/components/ui/dialog";
 import { isTimeRangeShorterThanTranscriptThreshold } from "@/lib/transcriptUtils";
 import { SummarizeDialog } from "@/components/dialogs/SummarizeDialog";
+import { TimeRangeCompact, TimeRangeEditDialog } from "@/components/TimeRangeEditDialog";
 
 // Details field with edit/preview toggle
 function DetailsField({ value, onChange }: { value: string; onChange: (value: string) => void }) {
@@ -98,6 +98,66 @@ function DetailsField({ value, onChange }: { value: string; onChange: (value: st
         <p className="text-xs text-muted-foreground">
           Supports Markdown: **bold**, *italic*, `code`, [links](url), lists, etc.
         </p>
+      )}
+    </div>
+  );
+}
+
+// Time Ranges Section with compact display and edit dialog
+interface TimeRange {
+  start: Date;
+  end?: Date;
+  name?: string;
+}
+
+function TimeRangesSection({ 
+  timeRanges, 
+  onUpdate 
+}: { 
+  timeRanges?: TimeRange[];
+  onUpdate: (ranges: TimeRange[] | undefined) => void;
+}) {
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+
+  if (!timeRanges || timeRanges.length === 0) {
+    return null;
+  }
+
+  const handleSave = (index: number, range: TimeRange) => {
+    const newRanges = [...timeRanges];
+    newRanges[index] = range;
+    onUpdate(newRanges);
+  };
+
+  const handleDelete = (index: number) => {
+    const newRanges = timeRanges.filter((_, i) => i !== index);
+    onUpdate(newRanges.length > 0 ? newRanges : undefined);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Label className="text-sm font-medium">Time Ranges</Label>
+      <div className="space-y-2">
+        {timeRanges.map((range, index) => (
+          <TimeRangeCompact
+            key={index}
+            timeRange={range}
+            index={index}
+            onEdit={setEditingIndex}
+            onDelete={handleDelete}
+          />
+        ))}
+      </div>
+      
+      {editingIndex !== null && timeRanges[editingIndex] && (
+        <TimeRangeEditDialog
+          open={editingIndex !== null}
+          onOpenChange={(open) => !open && setEditingIndex(null)}
+          timeRange={timeRanges[editingIndex]}
+          index={editingIndex}
+          onSave={handleSave}
+          onDelete={handleDelete}
+        />
       )}
     </div>
   );
@@ -917,77 +977,11 @@ export function ObjectForm(
         )}
       </div>
 
-      {/* Time Ranges - compact layout */}
-      {object.timeRanges && object.timeRanges.length > 0 && (
-        <div className="space-y-3">
-          <Label className="text-sm font-medium">Time Ranges</Label>
-          {(object.timeRanges || []).map((range, index) => (
-            <div key={index} className="border rounded-md p-3 bg-muted/20">
-              <div className="flex items-center justify-between gap-2 mb-2">
-                <Input
-                  value={range.name || ""}
-                  onChange={(e) => {
-                    const newRanges = [...(object.timeRanges || [])];
-                    newRanges[index] = { ...range, name: e.target.value || undefined };
-                    onUpdate({ timeRanges: newRanges });
-                  }}
-                  placeholder={`Time Range ${index + 1}`}
-                  className="h-8 text-sm font-medium bg-transparent border-none shadow-none px-0 focus-visible:ring-0"
-                />
-                <div className="flex items-center gap-1">
-                  {range.end && isTimeRangeShorterThanTranscriptThreshold(range.start, range.end) && (
-                    <Link to={`/transcript?start=${range.start.getTime()}&end=${range.end.getTime()}`}>
-                      <Button variant="ghost" size="sm" className="h-7 text-xs">
-                        Transcript
-                      </Button>
-                    </Link>
-                  )}
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 w-7 p-0"
-                    onClick={() => {
-                      const newRanges = (object.timeRanges || []).filter((_, i) => i !== index);
-                      onUpdate({ timeRanges: newRanges.length > 0 ? newRanges : undefined });
-                    }}
-                  >
-                    <Trash2 className="w-3.5 h-3.5 text-muted-foreground" />
-                  </Button>
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <Label className="text-xs text-muted-foreground">Start</Label>
-                  <DateTimePicker
-                    value={range.start}
-                    onChange={(date) => {
-                      if (date) {
-                        const newRanges = [...(object.timeRanges || [])];
-                        newRanges[index] = { ...range, start: date };
-                        onUpdate({ timeRanges: newRanges });
-                      }
-                    }}
-                    placeholder="Start time"
-                  />
-                </div>
-                <div>
-                  <Label className="text-xs text-muted-foreground">End</Label>
-                  <DateTimePicker
-                    nullable
-                    value={range.end}
-                    onChange={(date) => {
-                      const newRanges = [...(object.timeRanges || [])];
-                      newRanges[index] = { ...range, end: date || undefined };
-                      onUpdate({ timeRanges: newRanges });
-                    }}
-                    placeholder="End time"
-                  />
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
+      {/* Time Ranges - compact display with edit dialog */}
+      <TimeRangesSection 
+        timeRanges={object.timeRanges}
+        onUpdate={(newRanges) => onUpdate({ timeRanges: newRanges })}
+      />
 
       <div className="space-y-2">
 

--- a/frontend/src/components/ObjectForm.tsx
+++ b/frontend/src/components/ObjectForm.tsx
@@ -607,52 +607,52 @@ export function ObjectForm(
       {/* Object Type Toggle Buttons */}
       <div className={compact ? "space-y-1" : "space-y-2"}>
         <Label className={`text-muted-foreground ${compact ? 'text-xs' : 'text-sm'}`}>Object Type</Label>
-        <div className={`flex flex-wrap ${compact ? 'gap-1.5' : 'gap-2'}`}>
+        <div className={`flex flex-nowrap ${compact ? 'gap-1' : 'gap-2'}`}>
           <button
             type="button"
             onClick={() => updateField("isPerson", !object.isPerson)}
             className={`
-              flex items-center rounded-lg border-2 transition-all font-medium
-              ${compact ? 'gap-1.5 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
+              flex items-center rounded-md border transition-all font-medium whitespace-nowrap
+              ${compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-2 px-3 py-2 text-sm border-2'}
               ${object.isPerson
-                ? "bg-blue-500 text-white border-blue-600 shadow-md"
+                ? "bg-blue-500 text-white border-blue-600 shadow-sm"
                 : "bg-background border-border hover:bg-blue-50 hover:border-blue-300"
               }
             `}
           >
-            <User className={compact ? "w-3.5 h-3.5" : "w-4 h-4"} />
-            <span>Person</span>
+            <User className={compact ? "w-3 h-3" : "w-4 h-4"} />
+            <span>{compact ? "Pers" : "Person"}</span>
           </button>
 
           <button
             type="button"
             onClick={() => updateField("isEvent", !object.isEvent)}
             className={`
-              flex items-center rounded-lg border-2 transition-all font-medium
-              ${compact ? 'gap-1.5 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
+              flex items-center rounded-md border transition-all font-medium whitespace-nowrap
+              ${compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-2 px-3 py-2 text-sm border-2'}
               ${object.isEvent
-                ? "bg-green-500 text-white border-green-600 shadow-md"
+                ? "bg-green-500 text-white border-green-600 shadow-sm"
                 : "bg-background border-border hover:bg-green-50 hover:border-green-300"
               }
             `}
           >
-            <Calendar className={compact ? "w-3.5 h-3.5" : "w-4 h-4"} />
-            <span>Event</span>
+            <Calendar className={compact ? "w-3 h-3" : "w-4 h-4"} />
+            <span>{compact ? "Evt" : "Event"}</span>
           </button>
 
           <button
             type="button"
             onClick={() => updateField("isConversation", !object.isConversation)}
             className={`
-              flex items-center rounded-lg border-2 transition-all font-medium
-              ${compact ? 'gap-1.5 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
+              flex items-center rounded-md border transition-all font-medium whitespace-nowrap
+              ${compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-2 px-3 py-2 text-sm border-2'}
               ${object.isConversation
-                ? "bg-cyan-500 text-white border-cyan-600 shadow-md"
+                ? "bg-cyan-500 text-white border-cyan-600 shadow-sm"
                 : "bg-background border-border hover:bg-cyan-50 hover:border-cyan-300"
               }
             `}
           >
-            <MessageSquare className={compact ? "w-3.5 h-3.5" : "w-4 h-4"} />
+            <MessageSquare className={compact ? "w-3 h-3" : "w-4 h-4"} />
             <span>{compact ? "Conv" : "Conversation"}</span>
           </button>
 
@@ -673,15 +673,15 @@ export function ObjectForm(
               }
             }}
             className={`
-              flex items-center rounded-lg border-2 transition-all font-medium
-              ${compact ? 'gap-1.5 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
+              flex items-center rounded-md border transition-all font-medium whitespace-nowrap
+              ${compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-2 px-3 py-2 text-sm border-2'}
               ${object.isRelationship && !object.isPromise
-                ? "bg-purple-500 text-white border-purple-600 shadow-md"
+                ? "bg-purple-500 text-white border-purple-600 shadow-sm"
                 : "bg-background border-border hover:bg-purple-50 hover:border-purple-300"
               }
             `}
           >
-            <Users className={compact ? "w-3.5 h-3.5" : "w-4 h-4"} />
+            <Users className={compact ? "w-3 h-3" : "w-4 h-4"} />
             <span>{compact ? "Rel" : "Relationship"}</span>
           </button>
 
@@ -700,16 +700,16 @@ export function ObjectForm(
               }
             }}
             className={`
-              flex items-center rounded-lg border-2 transition-all font-medium
-              ${compact ? 'gap-1.5 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
+              flex items-center rounded-md border transition-all font-medium whitespace-nowrap
+              ${compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-2 px-3 py-2 text-sm border-2'}
               ${object.isPromise
-                ? "bg-orange-500 text-white border-orange-600 shadow-md"
+                ? "bg-orange-500 text-white border-orange-600 shadow-sm"
                 : "bg-background border-border hover:bg-orange-50 hover:border-orange-300"
               }
             `}
           >
-            <Handshake className={compact ? "w-3.5 h-3.5" : "w-4 h-4"} />
-            <span>Promise</span>
+            <Handshake className={compact ? "w-3 h-3" : "w-4 h-4"} />
+            <span>{compact ? "Prom" : "Promise"}</span>
           </button>
         </div>
       </div>

--- a/frontend/src/components/ObjectForm.tsx
+++ b/frontend/src/components/ObjectForm.tsx
@@ -173,6 +173,8 @@ interface ObjectFormProps {
   hideIconName?: boolean;
   /** Hide details section when displayed elsewhere on the page */
   hideDetails?: boolean;
+  /** Use compact layout with smaller text and spacing */
+  compact?: boolean;
 }
 
 const renderIcon = (icon: any) => {
@@ -323,7 +325,7 @@ function useDebouncedUpdate(
 }
 
 export function ObjectForm(
-  { object, onUpdate, onFieldUpdate, hideSummary, hideIconName, hideDetails }: ObjectFormProps,
+  { object, onUpdate, onFieldUpdate, hideSummary, hideIconName, hideDetails, compact = false }: ObjectFormProps,
 ) {
   const [newFieldName, setNewFieldName] = useState("");
   const [newFieldValue, setNewFieldValue] = useState("");
@@ -603,52 +605,55 @@ export function ObjectForm(
       )}
 
       {/* Object Type Toggle Buttons */}
-      <div className="space-y-2">
-        <Label className="text-sm text-muted-foreground">Object Type</Label>
-        <div className="flex flex-wrap gap-2">
+      <div className={compact ? "space-y-1" : "space-y-2"}>
+        <Label className={`text-muted-foreground ${compact ? 'text-xs' : 'text-sm'}`}>Object Type</Label>
+        <div className={`flex flex-wrap ${compact ? 'gap-1' : 'gap-2'}`}>
           <button
             type="button"
             onClick={() => updateField("isPerson", !object.isPerson)}
             className={`
-              flex items-center gap-2 px-3 py-2 rounded-lg border transition-all text-sm
+              flex items-center rounded-lg border transition-all
+              ${compact ? 'gap-1 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
               ${object.isPerson
                 ? "bg-blue-100 text-blue-800 border-blue-200"
                 : "bg-background border-border hover:bg-muted"
               }
             `}
           >
-            <User className="w-4 h-4" />
-            <span className="font-medium">Person</span>
+            <User className={compact ? "w-3 h-3" : "w-4 h-4"} />
+            {!compact && <span className="font-medium">Person</span>}
           </button>
 
           <button
             type="button"
             onClick={() => updateField("isEvent", !object.isEvent)}
             className={`
-              flex items-center gap-2 px-3 py-2 rounded-lg border transition-all text-sm
+              flex items-center rounded-lg border transition-all
+              ${compact ? 'gap-1 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
               ${object.isEvent
                 ? "bg-green-100 text-green-800 border-green-200"
                 : "bg-background border-border hover:bg-muted"
               }
             `}
           >
-            <Calendar className="w-4 h-4" />
-            <span className="font-medium">Event</span>
+            <Calendar className={compact ? "w-3 h-3" : "w-4 h-4"} />
+            {!compact && <span className="font-medium">Event</span>}
           </button>
 
           <button
             type="button"
             onClick={() => updateField("isConversation", !object.isConversation)}
             className={`
-              flex items-center gap-2 px-3 py-2 rounded-lg border transition-all text-sm
+              flex items-center rounded-lg border transition-all
+              ${compact ? 'gap-1 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
               ${object.isConversation
                 ? "bg-cyan-100 text-cyan-800 border-cyan-200"
                 : "bg-background border-border hover:bg-muted"
               }
             `}
           >
-            <MessageSquare className="w-4 h-4" />
-            <span className="font-medium">Conversation</span>
+            <MessageSquare className={compact ? "w-3 h-3" : "w-4 h-4"} />
+            {!compact && <span className="font-medium">Conversation</span>}
           </button>
 
           <button
@@ -668,15 +673,16 @@ export function ObjectForm(
               }
             }}
             className={`
-              flex items-center gap-2 px-3 py-2 rounded-lg border transition-all text-sm
+              flex items-center rounded-lg border transition-all
+              ${compact ? 'gap-1 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
               ${object.isRelationship && !object.isPromise
                 ? "bg-purple-100 text-purple-800 border-purple-200"
                 : "bg-background border-border hover:bg-muted"
               }
             `}
           >
-            <Users className="w-4 h-4" />
-            <span className="font-medium">Relationship</span>
+            <Users className={compact ? "w-3 h-3" : "w-4 h-4"} />
+            {!compact && <span className="font-medium">Relationship</span>}
           </button>
 
           <button
@@ -694,15 +700,16 @@ export function ObjectForm(
               }
             }}
             className={`
-              flex items-center gap-2 px-3 py-2 rounded-lg border transition-all text-sm
+              flex items-center rounded-lg border transition-all
+              ${compact ? 'gap-1 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
               ${object.isPromise
                 ? "bg-orange-100 text-orange-800 border-orange-200"
                 : "bg-background border-border hover:bg-muted"
               }
             `}
           >
-            <Handshake className="w-4 h-4" />
-            <span className="font-medium">Promise</span>
+            <Handshake className={compact ? "w-3 h-3" : "w-4 h-4"} />
+            {!compact && <span className="font-medium">Promise</span>}
           </button>
         </div>
       </div>

--- a/frontend/src/components/ObjectForm.tsx
+++ b/frontend/src/components/ObjectForm.tsx
@@ -107,6 +107,10 @@ interface ObjectFormProps {
   object: ObjectFormData;
   onUpdate?: (updates: Partial<ObjectFormData>) => Promise<void>;
   onFieldUpdate?: (field: string, value: any) => void;
+  /** Hide the summary section when already displayed elsewhere on the page */
+  hideSummary?: boolean;
+  /** Hide icon and name when displayed as page title */
+  hideIconName?: boolean;
 }
 
 const renderIcon = (icon: any) => {
@@ -257,7 +261,7 @@ function useDebouncedUpdate(
 }
 
 export function ObjectForm(
-  { object, onUpdate, onFieldUpdate }: ObjectFormProps,
+  { object, onUpdate, onFieldUpdate, hideSummary, hideIconName }: ObjectFormProps,
 ) {
   const [newFieldName, setNewFieldName] = useState("");
   const [newFieldValue, setNewFieldValue] = useState("");
@@ -373,28 +377,30 @@ export function ObjectForm(
 
   return (
     <div className="space-y-6">
-      <div className="flex items-start gap-4">
-        <div className="flex-shrink-0">
-          <Label className="text-sm font-medium">Icon</Label>
-          <div className="mt-1">
-            <EmojiPickerButton
-              value={object.icon}
-              onChange={(icon) => updateField("icon", icon)}
+      {!hideIconName && (
+        <div className="flex items-start gap-4">
+          <div className="flex-shrink-0">
+            <Label className="text-sm font-medium">Icon</Label>
+            <div className="mt-1">
+              <EmojiPickerButton
+                value={object.icon}
+                onChange={(icon) => updateField("icon", icon)}
+              />
+            </div>
+          </div>
+
+          <div className="flex-1">
+            <Label htmlFor="name" className="text-sm font-medium">Name</Label>
+            <Input
+              id="name"
+              value={nameValue}
+              onChange={(e) => setNameValue(e.target.value)}
+              placeholder="Object name"
+              className="mt-1"
             />
           </div>
         </div>
-
-        <div className="flex-1">
-          <Label htmlFor="name" className="text-sm font-medium">Name</Label>
-          <Input
-            id="name"
-            value={nameValue}
-            onChange={(e) => setNameValue(e.target.value)}
-            placeholder="Object name"
-            className="mt-1"
-          />
-        </div>
-      </div>
+      )}
 
       <DetailsField
         value={detailsValue}
@@ -484,7 +490,7 @@ export function ObjectForm(
         </DialogContent>
       </Dialog>
 
-      {object.summaries && object.summaries.length > 0 && (
+      {!hideSummary && object.summaries && object.summaries.length > 0 && (
         <div className="space-y-2">
           <Label className="text-sm font-medium">{object.summaries.length > 1 ? 'Summaries' : 'Summary'}</Label>
           <div className="space-y-3">
@@ -911,103 +917,77 @@ export function ObjectForm(
         )}
       </div>
 
-      <div className="space-y-2">
-        {object.timeRanges && object.timeRanges.length > 0 && (
-          <Label className="text-sm font-medium">Time Ranges</Label>
-        )}
+      {/* Time Ranges - compact layout */}
+      {object.timeRanges && object.timeRanges.length > 0 && (
         <div className="space-y-3">
+          <Label className="text-sm font-medium">Time Ranges</Label>
           {(object.timeRanges || []).map((range, index) => (
-            <div key={index} className="border rounded-md p-4 space-y-3">
-              <div className="flex justify-between items-start">
-                <Label className="text-xs text-muted-foreground">
-                  Range {index + 1}
-                </Label>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => {
-                    const newRanges = (object.timeRanges || []).filter((_, i) =>
-                      i !== index
-                    );
-                    onUpdate({
-                      timeRanges: newRanges.length > 0 ? newRanges : undefined,
-                    });
-                  }}
-                >
-                  <Trash2 className="w-4 h-4" />
-                </Button>
-              </div>
-
-              <div>
-                <Label htmlFor={`range-name-${index}`} className="text-xs">
-                  Name (optional)
-                </Label>
+            <div key={index} className="border rounded-md p-3 bg-muted/20">
+              <div className="flex items-center justify-between gap-2 mb-2">
                 <Input
-                  id={`range-name-${index}`}
                   value={range.name || ""}
                   onChange={(e) => {
                     const newRanges = [...(object.timeRanges || [])];
-                    newRanges[index] = {
-                      ...range,
-                      name: e.target.value || undefined,
-                    };
+                    newRanges[index] = { ...range, name: e.target.value || undefined };
                     onUpdate({ timeRanges: newRanges });
                   }}
-                  placeholder="Range name"
+                  placeholder={`Time Range ${index + 1}`}
+                  className="h-8 text-sm font-medium bg-transparent border-none shadow-none px-0 focus-visible:ring-0"
                 />
-              </div>
-              <div>
-                <Label htmlFor={`range-start-${index}`} className="text-xs">
-                  Start
-                </Label>
-                <DateTimePicker
-                  value={range.start}
-                  onChange={(date) => {
-                    if (date) {
-                      const newRanges = [...(object.timeRanges || [])];
-                      newRanges[index] = { ...range, start: date };
-                      onUpdate({ timeRanges: newRanges });
-                    }
-                  }}
-                  placeholder="Pick start time"
-                />
-              </div>
-              <div>
-                <Label htmlFor={`range-end-${index}`} className="text-xs">
-                  End (optional)
-                </Label>
-                <DateTimePicker
-                  nullable
-                  value={range.end}
-                  onChange={(date) => {
-                    const newRanges = [...(object.timeRanges || [])];
-                    newRanges[index] = { ...range, end: date || undefined };
-                    onUpdate({ timeRanges: newRanges });
-                  }}
-                  placeholder="Pick end time (optional)"
-                />
-              </div>
-
-              {/* Transcript button for ranges shorter than user-configured threshold */}
-              {range.end &&
-                isTimeRangeShorterThanTranscriptThreshold(
-                  range.start,
-                  range.end,
-                ) && (
-                <div className="pt-2 flex items-center gap-2">
-                  <Link
-                    to={`/transcript?start=${range.start.getTime()}&end=${range.end.getTime()}`}
+                <div className="flex items-center gap-1">
+                  {range.end && isTimeRangeShorterThanTranscriptThreshold(range.start, range.end) && (
+                    <Link to={`/transcript?start=${range.start.getTime()}&end=${range.end.getTime()}`}>
+                      <Button variant="ghost" size="sm" className="h-7 text-xs">
+                        Transcript
+                      </Button>
+                    </Link>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 w-7 p-0"
+                    onClick={() => {
+                      const newRanges = (object.timeRanges || []).filter((_, i) => i !== index);
+                      onUpdate({ timeRanges: newRanges.length > 0 ? newRanges : undefined });
+                    }}
                   >
-                    <Button variant="outline" size="sm">
-                      Go to transcript
-                    </Button>
-                  </Link>
+                    <Trash2 className="w-3.5 h-3.5 text-muted-foreground" />
+                  </Button>
                 </div>
-              )}
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <Label className="text-xs text-muted-foreground">Start</Label>
+                  <DateTimePicker
+                    value={range.start}
+                    onChange={(date) => {
+                      if (date) {
+                        const newRanges = [...(object.timeRanges || [])];
+                        newRanges[index] = { ...range, start: date };
+                        onUpdate({ timeRanges: newRanges });
+                      }
+                    }}
+                    placeholder="Start time"
+                  />
+                </div>
+                <div>
+                  <Label className="text-xs text-muted-foreground">End</Label>
+                  <DateTimePicker
+                    nullable
+                    value={range.end}
+                    onChange={(date) => {
+                      const newRanges = [...(object.timeRanges || [])];
+                      newRanges[index] = { ...range, end: date || undefined };
+                      onUpdate({ timeRanges: newRanges });
+                    }}
+                    placeholder="End time"
+                  />
+                </div>
+              </div>
             </div>
           ))}
         </div>
-      </div>
+      )}
 
       <div className="space-y-2">
 

--- a/frontend/src/components/ObjectForm.tsx
+++ b/frontend/src/components/ObjectForm.tsx
@@ -613,7 +613,7 @@ export function ObjectForm(
             onClick={() => updateField("isPerson", !object.isPerson)}
             className={`
               flex items-center rounded-lg border transition-all
-              ${compact ? 'gap-1 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
+              ${compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-2 px-3 py-2 text-sm'}
               ${object.isPerson
                 ? "bg-blue-100 text-blue-800 border-blue-200"
                 : "bg-background border-border hover:bg-muted"
@@ -621,7 +621,7 @@ export function ObjectForm(
             `}
           >
             <User className={compact ? "w-3 h-3" : "w-4 h-4"} />
-            {!compact && <span className="font-medium">Person</span>}
+            <span className={compact ? "" : "font-medium"}>{compact ? "Person" : "Person"}</span>
           </button>
 
           <button
@@ -629,7 +629,7 @@ export function ObjectForm(
             onClick={() => updateField("isEvent", !object.isEvent)}
             className={`
               flex items-center rounded-lg border transition-all
-              ${compact ? 'gap-1 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
+              ${compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-2 px-3 py-2 text-sm'}
               ${object.isEvent
                 ? "bg-green-100 text-green-800 border-green-200"
                 : "bg-background border-border hover:bg-muted"
@@ -637,7 +637,7 @@ export function ObjectForm(
             `}
           >
             <Calendar className={compact ? "w-3 h-3" : "w-4 h-4"} />
-            {!compact && <span className="font-medium">Event</span>}
+            <span className={compact ? "" : "font-medium"}>{compact ? "Event" : "Event"}</span>
           </button>
 
           <button
@@ -645,7 +645,7 @@ export function ObjectForm(
             onClick={() => updateField("isConversation", !object.isConversation)}
             className={`
               flex items-center rounded-lg border transition-all
-              ${compact ? 'gap-1 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
+              ${compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-2 px-3 py-2 text-sm'}
               ${object.isConversation
                 ? "bg-cyan-100 text-cyan-800 border-cyan-200"
                 : "bg-background border-border hover:bg-muted"
@@ -653,7 +653,7 @@ export function ObjectForm(
             `}
           >
             <MessageSquare className={compact ? "w-3 h-3" : "w-4 h-4"} />
-            {!compact && <span className="font-medium">Conversation</span>}
+            <span className={compact ? "" : "font-medium"}>{compact ? "Conv" : "Conversation"}</span>
           </button>
 
           <button
@@ -674,7 +674,7 @@ export function ObjectForm(
             }}
             className={`
               flex items-center rounded-lg border transition-all
-              ${compact ? 'gap-1 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
+              ${compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-2 px-3 py-2 text-sm'}
               ${object.isRelationship && !object.isPromise
                 ? "bg-purple-100 text-purple-800 border-purple-200"
                 : "bg-background border-border hover:bg-muted"
@@ -682,7 +682,7 @@ export function ObjectForm(
             `}
           >
             <Users className={compact ? "w-3 h-3" : "w-4 h-4"} />
-            {!compact && <span className="font-medium">Relationship</span>}
+            <span className={compact ? "" : "font-medium"}>{compact ? "Rel" : "Relationship"}</span>
           </button>
 
           <button
@@ -701,7 +701,7 @@ export function ObjectForm(
             }}
             className={`
               flex items-center rounded-lg border transition-all
-              ${compact ? 'gap-1 px-2 py-1 text-xs' : 'gap-2 px-3 py-2 text-sm'}
+              ${compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-2 px-3 py-2 text-sm'}
               ${object.isPromise
                 ? "bg-orange-100 text-orange-800 border-orange-200"
                 : "bg-background border-border hover:bg-muted"
@@ -709,7 +709,7 @@ export function ObjectForm(
             `}
           >
             <Handshake className={compact ? "w-3 h-3" : "w-4 h-4"} />
-            {!compact && <span className="font-medium">Promise</span>}
+            <span className={compact ? "" : "font-medium"}>{compact ? "Promise" : "Promise"}</span>
           </button>
         </div>
       </div>

--- a/frontend/src/components/ObjectForm.tsx
+++ b/frontend/src/components/ObjectForm.tsx
@@ -171,6 +171,8 @@ interface ObjectFormProps {
   hideSummary?: boolean;
   /** Hide icon and name when displayed as page title */
   hideIconName?: boolean;
+  /** Hide details section when displayed elsewhere on the page */
+  hideDetails?: boolean;
 }
 
 const renderIcon = (icon: any) => {
@@ -321,7 +323,7 @@ function useDebouncedUpdate(
 }
 
 export function ObjectForm(
-  { object, onUpdate, onFieldUpdate, hideSummary, hideIconName }: ObjectFormProps,
+  { object, onUpdate, onFieldUpdate, hideSummary, hideIconName, hideDetails }: ObjectFormProps,
 ) {
   const [newFieldName, setNewFieldName] = useState("");
   const [newFieldValue, setNewFieldValue] = useState("");
@@ -462,10 +464,12 @@ export function ObjectForm(
         </div>
       )}
 
-      <DetailsField
-        value={detailsValue}
-        onChange={setDetailsValue}
-      />
+      {!hideDetails && (
+        <DetailsField
+          value={detailsValue}
+          onChange={setDetailsValue}
+        />
+      )}
 
       <SummarizeDialog
         open={isSummarizeOpen}

--- a/frontend/src/components/ObjectForm.tsx
+++ b/frontend/src/components/ObjectForm.tsx
@@ -621,7 +621,7 @@ export function ObjectForm(
             `}
           >
             <User className={compact ? "w-3 h-3" : "w-4 h-4"} />
-            <span>{compact ? "Pers" : "Person"}</span>
+            <span>Person</span>
           </button>
 
           <button
@@ -637,7 +637,7 @@ export function ObjectForm(
             `}
           >
             <Calendar className={compact ? "w-3 h-3" : "w-4 h-4"} />
-            <span>{compact ? "Evt" : "Event"}</span>
+            <span>Event</span>
           </button>
 
           <button
@@ -653,7 +653,7 @@ export function ObjectForm(
             `}
           >
             <MessageSquare className={compact ? "w-3 h-3" : "w-4 h-4"} />
-            <span>{compact ? "Conv" : "Conversation"}</span>
+            <span>Conversation</span>
           </button>
 
           <button
@@ -682,7 +682,7 @@ export function ObjectForm(
             `}
           >
             <Users className={compact ? "w-3 h-3" : "w-4 h-4"} />
-            <span>{compact ? "Rel" : "Relationship"}</span>
+            <span>Relationship</span>
           </button>
 
           <button
@@ -709,7 +709,7 @@ export function ObjectForm(
             `}
           >
             <Handshake className={compact ? "w-3 h-3" : "w-4 h-4"} />
-            <span>{compact ? "Prom" : "Promise"}</span>
+            <span>Promise</span>
           </button>
         </div>
       </div>

--- a/frontend/src/components/ObjectPlayerTranscript.tsx
+++ b/frontend/src/components/ObjectPlayerTranscript.tsx
@@ -208,6 +208,16 @@ export function ObjectPlayerTranscript({ timeRange, height, minHeight = 300, max
     }
   }, [startDate, resetDate]);
 
+  // Stop playback when currentDate reaches endDate
+  useEffect(() => {
+    if (!isPlaying || !currentDate) return;
+
+    if (currentDate.getTime() >= endDate.getTime()) {
+      setIsPlaying(false);
+      resetDate(endDate);
+    }
+  }, [currentDate, endDate, isPlaying, setIsPlaying, resetDate]);
+
   // Fetch transcripts
   useEffect(() => {
     async function fetchTranscripts() {
@@ -262,29 +272,44 @@ export function ObjectPlayerTranscript({ timeRange, height, minHeight = 300, max
   // Handle user scroll - temporarily disable auto-scroll
   const handleScroll = useCallback(() => {
     if (!syncEnabled) return;
-    
+
     setUserScrolling(true);
-    
+
     // Clear any existing timeout
     if (scrollTimeoutRef.current) {
       clearTimeout(scrollTimeoutRef.current);
     }
-    
+
     // Re-enable auto-scroll after 3 seconds of no scrolling
     scrollTimeoutRef.current = window.setTimeout(() => {
       setUserScrolling(false);
     }, 3000);
   }, [syncEnabled]);
 
+  // Scroll to segment within container only (doesn't scroll the whole page)
+  const scrollToSegmentInContainer = useCallback((element: HTMLElement) => {
+    const scrollViewport = scrollAreaRef.current?.querySelector('[data-radix-scroll-area-viewport]');
+    if (!scrollViewport || !element) return;
+
+    const elementTop = element.offsetTop;
+    const containerHeight = scrollViewport.clientHeight;
+    const elementHeight = element.offsetHeight;
+    const targetScroll = elementTop - (containerHeight / 2) + (elementHeight / 2);
+
+    scrollViewport.scrollTo({ top: targetScroll, behavior: 'smooth' });
+  }, []);
+
   // Auto-scroll to current segment
   useEffect(() => {
     if (syncEnabled && !userScrolling && currentSegmentIndex >= 0 && currentSegmentIndex !== lastScrolledIndex.current) {
       lastScrolledIndex.current = currentSegmentIndex;
       setTimeout(() => {
-        currentSegmentRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+        if (currentSegmentRef.current) {
+          scrollToSegmentInContainer(currentSegmentRef.current);
+        }
       }, 100);
     }
-  }, [currentSegmentIndex, syncEnabled, userScrolling]);
+  }, [currentSegmentIndex, syncEnabled, userScrolling, scrollToSegmentInContainer]);
 
   // Cleanup timeout on unmount
   useEffect(() => {
@@ -461,9 +486,9 @@ export function ObjectPlayerTranscript({ timeRange, height, minHeight = 300, max
             asChild
             className="h-8 text-xs"
           >
-            <Link to={`/timeline?date=${(currentDate || startDate).getTime()}`}>
+            <Link to={`/timeline?start=${startDate.getTime()}&end=${endDate.getTime()}`}>
               <Calendar className="w-3.5 h-3.5 mr-1.5" />
-              Timeline
+              View in Timeline
             </Link>
           </Button>
         </div>

--- a/frontend/src/components/ObjectPlayerTranscript.tsx
+++ b/frontend/src/components/ObjectPlayerTranscript.tsx
@@ -20,6 +20,8 @@ import { cn } from "@/lib/utils";
 
 interface ObjectPlayerTranscriptProps {
   timeRange: { start: Date | string; end?: Date | string | null };
+  /** Height in pixels, defaults to 700 */
+  height?: number;
 }
 
 interface TranscriptSegment {
@@ -160,7 +162,7 @@ function WaveformDisplay({ segments, startDate, endDate, currentDate, onSeek }: 
   );
 }
 
-export function ObjectPlayerTranscript({ timeRange }: ObjectPlayerTranscriptProps) {
+export function ObjectPlayerTranscript({ timeRange, height = 700 }: ObjectPlayerTranscriptProps) {
   // Audio player state
   const { currentDate, resetDate, setIsPlaying, isPlaying } = useAudioPlayer();
   const { volume, setVolume, playbackRate, setPlaybackRate, timeFormat } = useSettingsStore();
@@ -362,7 +364,7 @@ export function ObjectPlayerTranscript({ timeRange }: ObjectPlayerTranscriptProp
   };
 
   return (
-    <div className="border rounded-lg bg-muted/30 flex flex-col h-[700px]">
+    <div className="border rounded-lg bg-muted/30 flex flex-col" style={{ height: `${height}px` }}>
       {/* Sticky Player Section */}
       <div className="flex-shrink-0 p-4 border-b bg-gradient-to-r from-muted/50 to-muted/30 rounded-t-lg space-y-3">
         {/* Waveform visualization */}

--- a/frontend/src/components/ObjectPlayerTranscript.tsx
+++ b/frontend/src/components/ObjectPlayerTranscript.tsx
@@ -20,8 +20,12 @@ import { cn } from "@/lib/utils";
 
 interface ObjectPlayerTranscriptProps {
   timeRange: { start: Date | string; end?: Date | string | null };
-  /** Height in pixels, defaults to 700 */
+  /** Fixed height in pixels (deprecated, use minHeight/maxHeight) */
   height?: number;
+  /** Minimum height in pixels */
+  minHeight?: number;
+  /** Maximum height in pixels */
+  maxHeight?: number;
 }
 
 interface TranscriptSegment {
@@ -162,7 +166,7 @@ function WaveformDisplay({ segments, startDate, endDate, currentDate, onSeek }: 
   );
 }
 
-export function ObjectPlayerTranscript({ timeRange, height = 700 }: ObjectPlayerTranscriptProps) {
+export function ObjectPlayerTranscript({ timeRange, height, minHeight = 300, maxHeight = 600 }: ObjectPlayerTranscriptProps) {
   // Audio player state
   const { currentDate, resetDate, setIsPlaying, isPlaying } = useAudioPlayer();
   const { volume, setVolume, playbackRate, setPlaybackRate, timeFormat } = useSettingsStore();
@@ -363,8 +367,12 @@ export function ObjectPlayerTranscript({ timeRange, height = 700 }: ObjectPlayer
     return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
   };
 
+  const containerStyle = height 
+    ? { height: `${height}px` }
+    : { minHeight: `${minHeight}px`, maxHeight: `${maxHeight}px` };
+
   return (
-    <div className="border rounded-lg bg-muted/30 flex flex-col" style={{ height: `${height}px` }}>
+    <div className="border rounded-lg bg-muted/30 flex flex-col" style={containerStyle}>
       {/* Sticky Player Section */}
       <div className="flex-shrink-0 p-4 border-b bg-gradient-to-r from-muted/50 to-muted/30 rounded-t-lg space-y-3">
         {/* Waveform visualization */}

--- a/frontend/src/components/ObjectPlayerTranscript.tsx
+++ b/frontend/src/components/ObjectPlayerTranscript.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef, useMemo, useCallback } from "react";
-import { Play, FileText, Link2, Link2Off, Volume2 } from "lucide-react";
+import { Link } from "react-router-dom";
+import { Play, FileText, Link2, Link2Off, Volume2, Calendar } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -449,6 +450,22 @@ export function ObjectPlayerTranscript({ timeRange, height, minHeight = 300, max
               className="flex-1"
             />
           </div>
+
+          {/* Divider */}
+          <div className="h-8 w-px bg-border hidden sm:block" />
+
+          {/* View in Timeline button */}
+          <Button
+            variant="outline"
+            size="sm"
+            asChild
+            className="h-8 text-xs"
+          >
+            <Link to={`/timeline?date=${(currentDate || startDate).getTime()}`}>
+              <Calendar className="w-3.5 h-3.5 mr-1.5" />
+              Timeline
+            </Link>
+          </Button>
         </div>
       </div>
 

--- a/frontend/src/components/ObjectPlayerTranscript.tsx
+++ b/frontend/src/components/ObjectPlayerTranscript.tsx
@@ -1,0 +1,553 @@
+import { useEffect, useState, useRef, useMemo, useCallback } from "react";
+import { Play, FileText, Link2, Link2Off, Volume2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Slider } from "@/components/ui/slider";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { callResource } from "@/lib/api";
+import { PlayPauseButton } from "@/modules/audio/PlayPauseButton";
+import { useAudioPlayer } from "@/modules/audio/player";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { formatTime } from "@/lib/formatTime";
+import { cn } from "@/lib/utils";
+
+interface ObjectPlayerTranscriptProps {
+  timeRange: { start: Date | string; end?: Date | string | null };
+}
+
+interface TranscriptSegment {
+  start: number;
+  end: number;
+  text: string;
+}
+
+interface TranscriptionDoc {
+  _id: unknown;
+  start: Date;
+  end: Date;
+  segments: TranscriptSegment[];
+}
+
+interface RenderSegment {
+  time: Date;
+  endTime: Date;
+  text: string;
+}
+
+const SPEED_OPTIONS = [
+  { value: 0.5, label: "0.5x" },
+  { value: 0.75, label: "0.75x" },
+  { value: 1, label: "1x" },
+  { value: 1.25, label: "1.25x" },
+  { value: 1.5, label: "1.5x" },
+  { value: 1.75, label: "1.75x" },
+  { value: 2, label: "2x" },
+  { value: 2.5, label: "2.5x" },
+  { value: 3, label: "3x" },
+];
+
+// Waveform visualization component based on transcript segments
+interface WaveformDisplayProps {
+  segments: RenderSegment[];
+  startDate: Date;
+  endDate: Date;
+  currentDate: Date | null;
+  onSeek: (date: Date) => void;
+}
+
+function WaveformDisplay({ segments, startDate, endDate, currentDate, onSeek }: WaveformDisplayProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const totalDuration = endDate.getTime() - startDate.getTime();
+  
+  // Generate waveform bars based on time buckets
+  const bars = useMemo(() => {
+    const numBars = 100; // Number of bars to display
+    const bucketSize = totalDuration / numBars;
+    const result: { intensity: number; hasVoice: boolean }[] = [];
+    
+    for (let i = 0; i < numBars; i++) {
+      const bucketStart = startDate.getTime() + i * bucketSize;
+      const bucketEnd = bucketStart + bucketSize;
+      
+      // Check if any segment overlaps with this bucket
+      let intensity = 0;
+      let hasVoice = false;
+      
+      for (const seg of segments) {
+        const segStart = seg.time.getTime();
+        const segEnd = seg.endTime.getTime();
+        
+        // Calculate overlap
+        const overlapStart = Math.max(bucketStart, segStart);
+        const overlapEnd = Math.min(bucketEnd, segEnd);
+        
+        if (overlapEnd > overlapStart) {
+          hasVoice = true;
+          // Calculate how much of the bucket is covered by speech
+          const coverage = (overlapEnd - overlapStart) / bucketSize;
+          // Add some variation based on text length
+          const textIntensity = Math.min(1, (seg.text.length / 100));
+          intensity = Math.max(intensity, coverage * (0.3 + textIntensity * 0.7));
+        }
+      }
+      
+      // Add slight noise for silent parts
+      if (!hasVoice) {
+        intensity = 0.05 + Math.random() * 0.05;
+      }
+      
+      result.push({ intensity, hasVoice });
+    }
+    
+    return result;
+  }, [segments, startDate, totalDuration]);
+  
+  // Calculate playhead position
+  const playheadPosition = currentDate 
+    ? ((currentDate.getTime() - startDate.getTime()) / totalDuration) * 100
+    : 0;
+  
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!containerRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const clickX = e.clientX - rect.left;
+    const percentage = clickX / rect.width;
+    const targetTime = new Date(startDate.getTime() + totalDuration * percentage);
+    onSeek(targetTime);
+  };
+  
+  return (
+    <div 
+      ref={containerRef}
+      className="relative h-12 bg-background/50 rounded cursor-pointer group"
+      onClick={handleClick}
+      title="Click to seek"
+    >
+      {/* Waveform bars */}
+      <div className="absolute inset-0 flex items-center justify-between gap-px px-1">
+        {bars.map((bar, idx) => (
+          <div
+            key={idx}
+            className={cn(
+              "flex-1 rounded-sm transition-all",
+              bar.hasVoice ? "bg-primary/60" : "bg-muted-foreground/20"
+            )}
+            style={{ 
+              height: `${Math.max(4, bar.intensity * 100)}%`,
+            }}
+          />
+        ))}
+      </div>
+      
+      {/* Playhead */}
+      <div 
+        className="absolute top-0 bottom-0 w-0.5 bg-primary shadow-lg z-10 transition-all duration-100"
+        style={{ left: `${Math.max(0, Math.min(100, playheadPosition))}%` }}
+      >
+        <div className="absolute -top-1 left-1/2 -translate-x-1/2 w-2 h-2 bg-primary rounded-full" />
+      </div>
+      
+      {/* Hover effect */}
+      <div className="absolute inset-0 bg-primary/5 opacity-0 group-hover:opacity-100 transition-opacity rounded" />
+    </div>
+  );
+}
+
+export function ObjectPlayerTranscript({ timeRange }: ObjectPlayerTranscriptProps) {
+  // Audio player state
+  const { currentDate, resetDate, setIsPlaying, isPlaying } = useAudioPlayer();
+  const { volume, setVolume, playbackRate, setPlaybackRate, timeFormat } = useSettingsStore();
+  const prevStartTimeRef = useRef<number | null>(null);
+
+  // Transcript state
+  const [segments, setSegments] = useState<RenderSegment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [syncEnabled, setSyncEnabled] = useState(true);
+  const [userScrolling, setUserScrolling] = useState(false);
+
+  const currentSegmentRef = useRef<HTMLDivElement>(null);
+  const lastScrolledIndex = useRef<number>(-1);
+  const scrollTimeoutRef = useRef<number | null>(null);
+  const scrollAreaRef = useRef<HTMLDivElement>(null);
+
+  // Parse dates
+  const startDate = useMemo(() => {
+    return typeof timeRange.start === "string"
+      ? new Date(timeRange.start)
+      : timeRange.start;
+  }, [timeRange.start]);
+
+  const endDate = useMemo(() => {
+    if (timeRange.end) {
+      return typeof timeRange.end === "string" ? new Date(timeRange.end) : timeRange.end;
+    }
+    return new Date(startDate.getTime() + 60 * 60 * 1000);
+  }, [timeRange.end, startDate]);
+
+  // Initialize player to start of time range
+  useEffect(() => {
+    const startTime = startDate.getTime();
+    if (prevStartTimeRef.current !== startTime) {
+      resetDate(startDate);
+      prevStartTimeRef.current = startTime;
+    }
+  }, [startDate, resetDate]);
+
+  // Fetch transcripts
+  useEffect(() => {
+    async function fetchTranscripts() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const docs: TranscriptionDoc[] = await callResource("mongo", {
+          action: "find",
+          collection: "transcriptions",
+          query: {
+            start: { $lt: endDate },
+            end: { $gt: startDate },
+          },
+          options: { sort: { start: 1 }, limit: 500 },
+        });
+
+        const rendered: RenderSegment[] = [];
+        for (const doc of docs) {
+          for (const s of doc.segments || []) {
+            const absStart = new Date(new Date(doc.start).getTime() + s.start * 1000);
+            const absEnd = new Date(new Date(doc.start).getTime() + s.end * 1000);
+            if (absEnd > startDate && absStart < endDate) {
+              rendered.push({
+                time: absStart,
+                endTime: absEnd,
+                text: (s.text || "").replace(/\n/g, " ").trim(),
+              });
+            }
+          }
+        }
+
+        rendered.sort((a, b) => a.time.getTime() - b.time.getTime());
+        setSegments(rendered);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to fetch transcripts");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchTranscripts();
+  }, [startDate, endDate]);
+
+  // Find current segment
+  const currentSegmentIndex = segments.findIndex(seg =>
+    currentDate &&
+    currentDate >= seg.time &&
+    currentDate < seg.endTime
+  );
+
+  // Handle user scroll - temporarily disable auto-scroll
+  const handleScroll = useCallback(() => {
+    if (!syncEnabled) return;
+    
+    setUserScrolling(true);
+    
+    // Clear any existing timeout
+    if (scrollTimeoutRef.current) {
+      clearTimeout(scrollTimeoutRef.current);
+    }
+    
+    // Re-enable auto-scroll after 3 seconds of no scrolling
+    scrollTimeoutRef.current = window.setTimeout(() => {
+      setUserScrolling(false);
+    }, 3000);
+  }, [syncEnabled]);
+
+  // Auto-scroll to current segment
+  useEffect(() => {
+    if (syncEnabled && !userScrolling && currentSegmentIndex >= 0 && currentSegmentIndex !== lastScrolledIndex.current) {
+      lastScrolledIndex.current = currentSegmentIndex;
+      setTimeout(() => {
+        currentSegmentRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+      }, 100);
+    }
+  }, [currentSegmentIndex, syncEnabled, userScrolling]);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (scrollTimeoutRef.current) {
+        clearTimeout(scrollTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handlePlayFromSegment = (segmentTime: Date) => {
+    resetDate(segmentTime);
+    setIsPlaying(true);
+    setUserScrolling(false); // Re-enable sync when user clicks a segment
+    lastScrolledIndex.current = -1; // Reset to force scroll
+  };
+
+  const handleVolumeChange = (value: number[]) => {
+    setVolume(value[0]);
+  };
+
+  const handleSpeedChange = (value: string) => {
+    setPlaybackRate(parseFloat(value));
+  };
+
+  // Calculate progress
+  const getProgress = () => {
+    if (!currentDate || !startDate) return 0;
+    const current = currentDate.getTime();
+    const start = startDate.getTime();
+    const end = endDate.getTime();
+    const progress = ((current - start) / (end - start)) * 100;
+    return Math.max(0, Math.min(100, progress));
+  };
+
+  // Format elapsed time
+  const getElapsedTime = () => {
+    if (!currentDate || !startDate) return "0:00";
+    const elapsedMs = currentDate.getTime() - startDate.getTime();
+    if (elapsedMs < 0) return "0:00";
+    const totalSeconds = Math.floor(elapsedMs / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    if (hours > 0) {
+      return `${hours}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+    }
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+  };
+
+  // Get total duration
+  const getTotalDuration = () => {
+    const durationMs = endDate.getTime() - startDate.getTime();
+    const totalSeconds = Math.floor(durationMs / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    if (hours > 0) {
+      return `${hours}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+    }
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+  };
+
+  // Handle progress bar click
+  const handleProgressClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const clickX = e.clientX - rect.left;
+    const percentage = clickX / rect.width;
+    const duration = endDate.getTime() - startDate.getTime();
+    const targetTime = new Date(startDate.getTime() + duration * percentage);
+    resetDate(targetTime);
+  };
+
+  // Format segment duration
+  const formatDuration = (start: Date, end: Date): string => {
+    const diffMs = end.getTime() - start.getTime();
+    const diffSeconds = Math.floor(diffMs / 1000);
+    if (diffSeconds < 60) return `${diffSeconds}s`;
+    const minutes = Math.floor(diffSeconds / 60);
+    const seconds = diffSeconds % 60;
+    return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  };
+
+  return (
+    <div className="border rounded-lg bg-muted/30 flex flex-col h-[700px]">
+      {/* Sticky Player Section */}
+      <div className="flex-shrink-0 p-4 border-b bg-gradient-to-r from-muted/50 to-muted/30 rounded-t-lg space-y-3">
+        {/* Waveform visualization */}
+        {segments.length > 0 && (
+          <WaveformDisplay
+            segments={segments}
+            startDate={startDate}
+            endDate={endDate}
+            currentDate={currentDate}
+            onSeek={resetDate}
+          />
+        )}
+        
+        <div className="flex flex-wrap items-center gap-4">
+          {/* Play button */}
+          <PlayPauseButton />
+
+          {/* Progress bar section */}
+          <div className="flex-1 min-w-[200px]">
+            <div
+              className="h-2 bg-background rounded-full overflow-hidden cursor-pointer hover:h-3 transition-all"
+              onClick={handleProgressClick}
+              title="Click to seek"
+            >
+              <div
+                className="h-full bg-primary transition-all duration-200"
+                style={{ width: `${getProgress()}%` }}
+              />
+            </div>
+          </div>
+
+          {/* Time display */}
+          <div className="flex flex-col items-end">
+            <span className="text-sm font-mono font-medium">
+              {getElapsedTime()} / {getTotalDuration()}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {currentDate ? formatTime(currentDate, timeFormat) : "Ready"}
+            </span>
+          </div>
+
+          {/* Divider */}
+          <div className="h-8 w-px bg-border hidden sm:block" />
+
+          {/* Speed selector */}
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground hidden sm:inline">Speed</span>
+            <Select
+              value={playbackRate.toString()}
+              onValueChange={handleSpeedChange}
+            >
+              <SelectTrigger className="w-[70px] h-8 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SPEED_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value.toString()}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Volume slider */}
+          <div className="flex items-center gap-2 min-w-[120px]">
+            <Volume2 className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+            <Slider
+              value={[volume]}
+              onValueChange={handleVolumeChange}
+              min={0}
+              max={2}
+              step={0.01}
+              className="flex-1"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Transcript Header */}
+      <div className="flex-shrink-0 flex items-center justify-between px-4 py-2 border-b">
+        <h3 className="text-sm font-semibold text-muted-foreground flex items-center gap-2">
+          <FileText className="w-4 h-4" />
+          Transcript
+          {!loading && segments.length > 0 && (
+            <span className="text-xs font-normal">({segments.length} segments)</span>
+          )}
+        </h3>
+        <div className="flex items-center gap-2">
+          {syncEnabled && isPlaying && !userScrolling && (
+            <span className="text-xs text-primary animate-pulse">Following</span>
+          )}
+          {syncEnabled && userScrolling && (
+            <span className="text-xs text-muted-foreground">Paused</span>
+          )}
+          <Button
+            variant={syncEnabled ? "secondary" : "ghost"}
+            size="sm"
+            onClick={() => {
+              setSyncEnabled(!syncEnabled);
+              setUserScrolling(false);
+            }}
+            title={syncEnabled ? "Sync enabled - click to disable" : "Sync disabled - click to enable"}
+            className="h-7 px-2 gap-1"
+          >
+            {syncEnabled ? (
+              <Link2 className="w-3.5 h-3.5" />
+            ) : (
+              <Link2Off className="w-3.5 h-3.5" />
+            )}
+            <span className="text-xs">{syncEnabled ? "Sync" : "No sync"}</span>
+          </Button>
+        </div>
+      </div>
+
+      {/* Scrollable Transcript Area */}
+      <div className="flex-1 overflow-hidden">
+        {loading ? (
+          <div className="p-4 space-y-3">
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+          </div>
+        ) : error ? (
+          <div className="p-4">
+            <p className="text-sm text-red-500">{error}</p>
+          </div>
+        ) : segments.length === 0 ? (
+          <div className="p-4">
+            <p className="text-sm text-muted-foreground text-center py-4">
+              No transcript available for this time range
+            </p>
+          </div>
+        ) : (
+          <ScrollArea 
+            className="h-full [&>[data-radix-scroll-area-viewport]]:!overflow-y-scroll" 
+            ref={scrollAreaRef}
+            onScrollCapture={handleScroll}
+          >
+            <div className="p-3 space-y-1">
+              {segments.map((seg, idx) => {
+                const isCurrentSegment = syncEnabled && idx === currentSegmentIndex;
+                return (
+                  <div
+                    key={idx}
+                    ref={isCurrentSegment ? currentSegmentRef : null}
+                    className={cn(
+                      "group flex items-start gap-2 p-2 rounded transition-colors cursor-pointer",
+                      isCurrentSegment
+                        ? "bg-primary/10 border-l-2 border-primary"
+                        : "hover:bg-muted/80"
+                    )}
+                    onClick={() => handlePlayFromSegment(seg.time)}
+                  >
+                    <div className={cn(
+                      "flex-shrink-0 w-6 h-6 flex items-center justify-center",
+                      isCurrentSegment ? "text-primary" : "text-muted-foreground opacity-0 group-hover:opacity-100"
+                    )}>
+                      <Play className="w-3 h-3" />
+                    </div>
+
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-0.5">
+                        <span className={cn(
+                          "text-xs font-mono",
+                          isCurrentSegment ? "text-primary font-medium" : "text-muted-foreground"
+                        )}>
+                          {formatTime(seg.time, timeFormat)}
+                        </span>
+                        <span className="text-xs text-muted-foreground/60">
+                          ({formatDuration(seg.time, seg.endTime)})
+                        </span>
+                      </div>
+                      <p className={cn(
+                        "text-sm leading-relaxed",
+                        isCurrentSegment && "font-medium"
+                      )}>{seg.text}</p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </ScrollArea>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/RelationshipsPanel.tsx
+++ b/frontend/src/components/RelationshipsPanel.tsx
@@ -72,12 +72,12 @@ export function RelationshipsPanel({ object }: RelationshipsPanelProps) {
 
   const handleCreateRelationship = async () => {
     if (!newRelationship.name.trim()) {
-      setCreateError("Relationship name is required");
+      setCreateError("Please enter a relationship name (e.g., 'knows', 'works with')");
       return;
     }
 
     if (!newRelationship.objectId) {
-      setCreateError("Please select the object");
+      setCreateError("Please select the target object (right side) for this relationship");
       return;
     }
 
@@ -218,21 +218,24 @@ export function RelationshipsPanel({ object }: RelationshipsPanelProps) {
               <Input
                 id="rel-name"
                 value={newRelationship.name}
-                onChange={(e) =>
+                onChange={(e) => {
                   setNewRelationship((prev) => ({
                     ...prev,
                     name: e.target.value,
-                  }))}
+                  }));
+                  if (createError) setCreateError(null);
+                }}
                 placeholder="e.g., knows, works with, manages"
                 className="mt-1"
               />
             </div>
           </div>
 
-          <div className="grid grid-cols-[1fr_auto_1fr] gap-4 items-end">
+          {/* Source and Target Objects - stacked layout for narrow containers */}
+          <div className="space-y-3">
             <div>
               <div className="flex items-center gap-2 mb-1">
-                <Label className="text-xs">Subject</Label>
+                <Label className="text-xs">Source Object</Label>
                 {!newRelationship.symmetrical && (
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -266,41 +269,46 @@ export function RelationshipsPanel({ object }: RelationshipsPanelProps) {
                     }));
                   }
                 }}
-                placeholder="Select a subject..."
+                placeholder="Select source object..."
               />
             </div>
 
-            <div className="flex items-center justify-center">
+            <div className="flex items-center gap-2">
+              <div className="flex-1 h-px bg-border" />
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
-                    variant="ghost"
-                    size="icon"
+                    variant="outline"
+                    size="sm"
                     onClick={() => {
                       setNewRelationship((prev) => ({
                         ...prev,
                         symmetrical: !prev.symmetrical,
                       }));
                     }}
-                    className="h-[40px] w-[40px] p-0"
+                    className="h-7 px-2 gap-1"
                   >
                     {newRelationship.symmetrical
-                      ? <MoveHorizontal className="w-4 h-4" />
-                      : <ArrowRight className="w-4 h-4" />}
+                      ? <MoveHorizontal className="w-3 h-3" />
+                      : <ArrowRight className="w-3 h-3" />}
+                    <span className="text-xs">
+                      {newRelationship.symmetrical ? "Bidirectional" : "Directional"}
+                    </span>
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>
                   <p>
                     {newRelationship.symmetrical
-                      ? "Make Directional"
-                      : "Make Symmetrical"}
+                      ? "Click to make directional (one-way)"
+                      : "Click to make bidirectional (both ways)"}
                   </p>
                 </TooltipContent>
               </Tooltip>
+              <div className="flex-1 h-px bg-border" />
             </div>
 
             <div>
-              <Label className="text-xs mb-1 block">Object</Label>
+              <Label className="text-xs mb-1 block">Target Object</Label>
               <ObjectSelectionDropdown
                 value={newRelationship.objectId}
                 onChange={(value) => {
@@ -309,10 +317,16 @@ export function RelationshipsPanel({ object }: RelationshipsPanelProps) {
                       ...prev,
                       objectId: value,
                     }));
+                    if (createError) setCreateError(null);
                   }
                 }}
-                placeholder="Select an object..."
+                placeholder="Select target object..."
               />
+              {!newRelationship.objectId && (
+                <p className="text-xs text-muted-foreground mt-1">
+                  Select the object this relationship points to
+                </p>
+              )}
             </div>
           </div>
 

--- a/frontend/src/components/RelationshipsPanel.tsx
+++ b/frontend/src/components/RelationshipsPanel.tsx
@@ -129,45 +129,60 @@ export function RelationshipsPanel({ object, compact = false }: RelationshipsPan
   };
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold">Relationships</h3>
+    <div className={compact ? "space-y-2" : "space-y-4"}>
+      {/* Header with title, counts inline, and create button */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-3">
+          <h3 className={compact ? "text-sm font-semibold" : "text-lg font-semibold"}>Relationships</h3>
+          {/* Inline counts when compact */}
+          {compact && referenceCounts && (
+            <div className="flex items-center gap-2 text-xs">
+              <span className="font-bold text-primary">{referenceCounts.referencesTo}</span>
+              <span className="text-muted-foreground text-[10px]">TO</span>
+              <span className="font-bold text-primary">{referenceCounts.referencesFrom}</span>
+              <span className="text-muted-foreground text-[10px]">FROM</span>
+              <span className="font-bold text-primary">{referenceCounts.total}</span>
+              <span className="text-muted-foreground text-[10px]">Total</span>
+            </div>
+          )}
+        </div>
         {!showCreateForm && (
           <Button
             variant="outline"
             size="sm"
+            className={compact ? "h-6 text-xs px-2" : ""}
             onClick={() => setShowCreateForm(true)}
           >
-            <Plus className="w-4 h-4 mr-2" />
-            Create Relationship
+            <Plus className={compact ? "w-3 h-3 mr-1" : "w-4 h-4 mr-2"} />
+            {compact ? "Add" : "Create Relationship"}
           </Button>
         )}
       </div>
 
-      {/* Reference Counts Display */}
-      {referenceCounts && (
-        <div className={`grid grid-cols-3 gap-2 p-2 bg-muted/30 rounded-lg border ${compact ? 'text-xs' : ''}`}>
+      {/* Reference Counts Display - only show when not compact */}
+      {!compact && referenceCounts && (
+        <div className="grid grid-cols-3 gap-2 p-2 bg-muted/30 rounded-lg border">
           <div className="text-center">
-            <div className={`font-bold text-primary ${compact ? 'text-lg' : 'text-2xl'}`}>
+            <div className="font-bold text-primary text-2xl">
               {referenceCounts.referencesTo}
             </div>
-            <div className={`text-muted-foreground ${compact ? 'text-[10px]' : 'text-xs mt-1'}`}>
+            <div className="text-muted-foreground text-xs mt-1">
               TO
             </div>
           </div>
           <div className="text-center">
-            <div className={`font-bold text-primary ${compact ? 'text-lg' : 'text-2xl'}`}>
+            <div className="font-bold text-primary text-2xl">
               {referenceCounts.referencesFrom}
             </div>
-            <div className={`text-muted-foreground ${compact ? 'text-[10px]' : 'text-xs mt-1'}`}>
+            <div className="text-muted-foreground text-xs mt-1">
               FROM
             </div>
           </div>
           <div className="text-center">
-            <div className={`font-bold text-primary ${compact ? 'text-lg' : 'text-2xl'}`}>
+            <div className="font-bold text-primary text-2xl">
               {referenceCounts.total}
             </div>
-            <div className={`text-muted-foreground ${compact ? 'text-[10px]' : 'text-xs mt-1'}`}>
+            <div className="text-muted-foreground text-xs mt-1">
               Total
             </div>
           </div>
@@ -369,7 +384,7 @@ export function RelationshipsPanel({ object, compact = false }: RelationshipsPan
         </div>
       )}
       {relationships.length > 0 && (
-        <div className="flex flex-col gap-2">
+        <div className={`flex flex-col ${compact ? 'gap-1' : 'gap-2'}`}>
           {relationships.map(({ other, relationship }) => {
             // Determine if current object is subject or object in the relationship
             const isCurrentObjectSubject =
@@ -383,29 +398,29 @@ export function RelationshipsPanel({ object, compact = false }: RelationshipsPan
               : (isCurrentObjectSubject ? ArrowRight : ArrowLeft);
 
             return (
-              <div key={relationship._id.toString()} className="p-1 space-y-2">
+              <div key={relationship._id.toString()} className={compact ? "py-0.5" : "p-1 space-y-2"}>
                 {/* Horizontal relationship flow */}
                 <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3 flex-1 min-w-0">
+                  <div className={`flex items-center flex-1 min-w-0 ${compact ? 'gap-1.5 text-xs' : 'gap-3'}`}>
                     <Link
                       to={`/objects/${relationship._id.toString()}`}
-                      className="flex items-center gap-2 flex-shrink-0"
+                      className={`flex items-center flex-shrink-0 ${compact ? 'gap-1' : 'gap-2'}`}
                     >
-                      <span className="text-md">
+                      <span className={compact ? "text-sm" : "text-md"}>
                         {renderIcon(relationship.icon)}
                       </span>
-                      <span className="font-medium whitespace-nowrap">
+                      <span className={`font-medium whitespace-nowrap ${compact ? 'text-xs' : ''}`}>
                         {relationship.name}
                       </span>
 
-                      <ArrowComponent className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+                      <ArrowComponent className={`text-muted-foreground flex-shrink-0 ${compact ? 'w-3 h-3' : 'w-4 h-4'}`} />
                     </Link>
                     <Link
                       to={`/objects/${other._id.toString()}`}
-                      className="flex items-center gap-2 min-w-0"
+                      className={`flex items-center min-w-0 ${compact ? 'gap-1' : 'gap-2'}`}
                     >
-                      <span className="text-md">{renderIcon(other.icon)}</span>
-                      <span className="font-medium truncate">{other.name}</span>
+                      <span className={compact ? "text-sm" : "text-md"}>{renderIcon(other.icon)}</span>
+                      <span className={`font-medium truncate ${compact ? 'text-xs' : ''}`}>{other.name}</span>
                     </Link>
                   </div>
                   <Tooltip>
@@ -416,9 +431,9 @@ export function RelationshipsPanel({ object, compact = false }: RelationshipsPan
                         onClick={() =>
                           handleDeleteRelationship(relationship._id.toString())}
                         disabled={deleteObjectMutation.isPending}
-                        className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                        className={`text-muted-foreground hover:text-destructive ${compact ? 'h-5 w-5' : 'h-8 w-8'}`}
                       >
-                        <Trash2 className="w-4 h-4" />
+                        <Trash2 className={compact ? "w-3 h-3" : "w-4 h-4"} />
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>
@@ -427,8 +442,8 @@ export function RelationshipsPanel({ object, compact = false }: RelationshipsPan
                   </Tooltip>
                 </div>
 
-                {/* Relationship description and time ranges below */}
-                {(relationship.details ||
+                {/* Relationship description and time ranges below - hide in compact mode */}
+                {!compact && (relationship.details ||
                   (relationship.timeRanges &&
                     relationship.timeRanges.length > 0)) && (
                   <div className="text-sm text-muted-foreground pl-2 space-y-1">

--- a/frontend/src/components/RelationshipsPanel.tsx
+++ b/frontend/src/components/RelationshipsPanel.tsx
@@ -34,6 +34,8 @@ import {
 
 interface RelationshipsPanelProps {
   object: Object;
+  /** Use compact layout with smaller text and spacing */
+  compact?: boolean;
 }
 
 const renderIcon = (icon: any) => {
@@ -44,7 +46,7 @@ const renderIcon = (icon: any) => {
   return "";
 };
 
-export function RelationshipsPanel({ object }: RelationshipsPanelProps) {
+export function RelationshipsPanel({ object, compact = false }: RelationshipsPanelProps) {
   const { data: relationships = [] } = getRelationships(object._id);
   const { data: referenceCounts } = useObjectReferenceCounts(object._id);
   const createObjectMutation = useCreateObject();
@@ -144,38 +146,29 @@ export function RelationshipsPanel({ object }: RelationshipsPanelProps) {
 
       {/* Reference Counts Display */}
       {referenceCounts && (
-        <div className="grid grid-cols-3 gap-3 p-3 bg-muted/30 rounded-lg border">
+        <div className={`grid grid-cols-3 gap-2 p-2 bg-muted/30 rounded-lg border ${compact ? 'text-xs' : ''}`}>
           <div className="text-center">
-            <div className="text-2xl font-bold text-primary">
+            <div className={`font-bold text-primary ${compact ? 'text-lg' : 'text-2xl'}`}>
               {referenceCounts.referencesTo}
             </div>
-            <div className="text-xs text-muted-foreground mt-1">
-              References TO
-            </div>
-            <div className="text-xs text-muted-foreground/70 mt-0.5">
-              (as target)
+            <div className={`text-muted-foreground ${compact ? 'text-[10px]' : 'text-xs mt-1'}`}>
+              TO
             </div>
           </div>
           <div className="text-center">
-            <div className="text-2xl font-bold text-primary">
+            <div className={`font-bold text-primary ${compact ? 'text-lg' : 'text-2xl'}`}>
               {referenceCounts.referencesFrom}
             </div>
-            <div className="text-xs text-muted-foreground mt-1">
-              References FROM
-            </div>
-            <div className="text-xs text-muted-foreground/70 mt-0.5">
-              (as source)
+            <div className={`text-muted-foreground ${compact ? 'text-[10px]' : 'text-xs mt-1'}`}>
+              FROM
             </div>
           </div>
           <div className="text-center">
-            <div className="text-2xl font-bold text-primary">
+            <div className={`font-bold text-primary ${compact ? 'text-lg' : 'text-2xl'}`}>
               {referenceCounts.total}
             </div>
-            <div className="text-xs text-muted-foreground mt-1">
+            <div className={`text-muted-foreground ${compact ? 'text-[10px]' : 'text-xs mt-1'}`}>
               Total
-            </div>
-            <div className="text-xs text-muted-foreground/70 mt-0.5">
-              relationships
             </div>
           </div>
         </div>

--- a/frontend/src/components/TimeRangeEditDialog.tsx
+++ b/frontend/src/components/TimeRangeEditDialog.tsx
@@ -1,0 +1,213 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { DateTimePicker } from "@/components/ui/datetime-picker";
+import { formatTime } from "@/lib/formatTime";
+import { Pencil, Trash2 } from "lucide-react";
+
+interface TimeRange {
+  start: Date;
+  end?: Date;
+  name?: string;
+}
+
+interface TimeRangeEditDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  timeRange: TimeRange;
+  index: number;
+  onSave: (index: number, range: TimeRange) => void;
+  onDelete: (index: number) => void;
+}
+
+export function TimeRangeEditDialog({
+  open,
+  onOpenChange,
+  timeRange,
+  index,
+  onSave,
+  onDelete,
+}: TimeRangeEditDialogProps) {
+  const [name, setName] = useState(timeRange.name || "");
+  const [start, setStart] = useState<Date>(timeRange.start);
+  const [end, setEnd] = useState<Date | undefined>(timeRange.end);
+
+  const handleSave = () => {
+    onSave(index, {
+      start,
+      end,
+      name: name.trim() || undefined,
+    });
+    onOpenChange(false);
+  };
+
+  const handleDelete = () => {
+    onDelete(index);
+    onOpenChange(false);
+  };
+
+  // Format duration
+  const getDuration = () => {
+    if (!start || !end) return null;
+    const diffMs = end.getTime() - start.getTime();
+    const diffMins = Math.floor(diffMs / (1000 * 60));
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+    
+    if (diffMins < 1) return "< 1 minute";
+    if (diffMins < 60) return `${diffMins} minute${diffMins !== 1 ? "s" : ""}`;
+    if (diffHours < 24) {
+      const mins = diffMins % 60;
+      return mins > 0 ? `${diffHours}h ${mins}m` : `${diffHours} hour${diffHours !== 1 ? "s" : ""}`;
+    }
+    return `${diffDays} day${diffDays !== 1 ? "s" : ""}`;
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Edit Time Range {index + 1}</DialogTitle>
+        </DialogHeader>
+        
+        <div className="space-y-4 py-4">
+          {/* Name */}
+          <div className="space-y-2">
+            <Label htmlFor="range-name">Name (optional)</Label>
+            <Input
+              id="range-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g., Meeting, Event, etc."
+            />
+          </div>
+
+          {/* Start Time */}
+          <div className="space-y-2">
+            <Label>Start Time</Label>
+            <DateTimePicker
+              value={start}
+              onChange={(date) => date && setStart(date)}
+              placeholder="Select start time"
+            />
+          </div>
+
+          {/* End Time */}
+          <div className="space-y-2">
+            <Label>End Time (optional)</Label>
+            <DateTimePicker
+              value={end}
+              onChange={(date) => setEnd(date || undefined)}
+              placeholder="Select end time"
+              nullable
+            />
+          </div>
+
+          {/* Duration display */}
+          {getDuration() && (
+            <div className="text-sm text-muted-foreground">
+              Duration: <span className="font-medium">{getDuration()}</span>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="flex justify-between">
+          <Button variant="destructive" size="sm" onClick={handleDelete}>
+            <Trash2 className="w-4 h-4 mr-2" />
+            Delete
+          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave}>
+              Save Changes
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// Compact display component for time ranges
+interface TimeRangeCompactProps {
+  timeRange: TimeRange;
+  index: number;
+  onEdit: (index: number) => void;
+  onDelete: (index: number) => void;
+}
+
+export function TimeRangeCompact({
+  timeRange,
+  index,
+  onEdit,
+  onDelete,
+}: TimeRangeCompactProps) {
+  const formatDateTime = (date: Date): string => {
+    return formatTime(date);
+  };
+
+  const getDuration = () => {
+    if (!timeRange.end) return "Ongoing";
+    const diffMs = timeRange.end.getTime() - timeRange.start.getTime();
+    const diffMins = Math.floor(diffMs / (1000 * 60));
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    
+    if (diffMins < 60) return `${diffMins}m`;
+    if (diffHours < 24) {
+      const mins = diffMins % 60;
+      return mins > 0 ? `${diffHours}h ${mins}m` : `${diffHours}h`;
+    }
+    const days = Math.floor(diffHours / 24);
+    return `${days}d`;
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-2 p-2 border rounded-md bg-muted/20 group">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          {timeRange.name && (
+            <span className="text-sm font-medium truncate">{timeRange.name}</span>
+          )}
+          {!timeRange.name && (
+            <span className="text-sm text-muted-foreground">Time Range {index + 1}</span>
+          )}
+          <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+            {getDuration()}
+          </span>
+        </div>
+        <div className="text-xs text-muted-foreground truncate">
+          {formatDateTime(timeRange.start)}
+          {timeRange.end && ` → ${formatDateTime(timeRange.end)}`}
+        </div>
+      </div>
+      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0"
+          onClick={() => onEdit(index)}
+        >
+          <Pencil className="w-3.5 h-3.5" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0"
+          onClick={() => onDelete(index)}
+        >
+          <Trash2 className="w-3.5 h-3.5 text-muted-foreground" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/formatTime.ts
+++ b/frontend/src/lib/formatTime.ts
@@ -9,6 +9,17 @@ export function formatTime(date: Date, format?: TimeFormat): string {
   const actualFormat = format || useSettingsStore.getState().timeFormat;
 
   switch (actualFormat) {
+    case "gregorian-local-natural":
+      return date.toLocaleString("en-US", {
+        weekday: "short",
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        hour12: true,
+      });
+
     case "gregorian-local-iso":
       return date.toLocaleString("sv-SE", {
         year: "numeric",

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -23,10 +23,12 @@ import {
 } from "lucide-react";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { SmartBackButton } from "@/components/SmartBackButton";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   useDeleteObject,
   useObject,
   useUpdateObject,
+  objectKeys,
 } from "@/hooks/useObjectQueries";
 import { ObjectForm } from "@/components/ObjectForm";
 import { RelationshipsPanel } from "@/components/RelationshipsPanel";
@@ -166,6 +168,7 @@ function EditableTitle({
 const ObjectDetailPage = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   // Use React Query hooks
   const { data: object, isLoading: loading, error } = useObject(id);
   const updateObjectMutation = useUpdateObject();
@@ -185,7 +188,9 @@ const ObjectDetailPage = () => {
   const { autoSave, setAutoSave, dateFormat } = useSettingsStore();
   const [pendingChanges, setPendingChanges] = useState<Record<string, any>>({});
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
   const [, forceUpdate] = useState(0); // For relative time updates
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   
   // Update relative time every minute
   useEffect(() => {
@@ -193,103 +198,90 @@ const ObjectDetailPage = () => {
     return () => clearInterval(interval);
   }, []);
 
-  // Per-field timeouts map for throttled saves
-  const fieldTimeoutsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
-
-  // Throttled save function - saves after 2 seconds of inactivity per field
-  const throttledSave = useCallback((field: string, value: any) => {
-    if (!object || !id) return;
-
-    // Clear existing timeout for THIS field only
-    const existingTimeout = fieldTimeoutsRef.current.get(field);
-    if (existingTimeout) {
-      clearTimeout(existingTimeout);
-    }
-
-    // Set new timeout for 2 seconds for THIS field
-    const timeout = setTimeout(() => {
-      updateObjectMutation.mutate({
-        id: object._id.toString(),
-        version: object.version,
-        field,
-        value,
-      }, {
-        onSuccess: () => {
-          setLastSaved(new Date());
-          // Clear this field from pending changes after successful save
-          setPendingChanges(prev => {
-            const { [field]: _, ...rest } = prev;
-            return rest;
-          });
-          // Remove from timeouts map
-          fieldTimeoutsRef.current.delete(field);
-        },
-        onError: () => {
-          // Remove from timeouts map on error too
-          fieldTimeoutsRef.current.delete(field);
-        },
-      });
-    }, 2000);
-
-    fieldTimeoutsRef.current.set(field, timeout);
-  }, [object, id, updateObjectMutation]);
-
-  // Cleanup all timeouts on unmount
+  // Cleanup timeout on unmount
   useEffect(() => {
     return () => {
-      fieldTimeoutsRef.current.forEach((timeout) => clearTimeout(timeout));
-      fieldTimeoutsRef.current.clear();
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
     };
   }, []);
 
-  const handleFieldUpdate = useCallback((field: string, value: any) => {
-    if (!object || !id) return;
-
-    // Always update pendingChanges immediately for instant visual feedback
-    setPendingChanges(prev => ({ ...prev, [field]: value }));
-
-    if (autoSave) {
-      // Use throttled save with 2 second delay
-      throttledSave(field, value);
-    }
-    // When autosave is off, changes stay in pendingChanges until manual save
-  }, [object, id, autoSave, throttledSave]);
-
-  // Manual save function - saves all pending changes sequentially
-  const handleManualSave = useCallback(async () => {
-    if (!object || !id || Object.keys(pendingChanges).length === 0) return;
-
+  // Core save function - saves all pending changes sequentially with proper version tracking
+  const saveAllPendingChanges = useCallback(async () => {
+    // Get current object from cache to ensure we have the latest version
+    const currentObject = queryClient.getQueryData<typeof object>(objectKeys.detail(id!));
+    if (!currentObject || !id) return;
+    
+    // Snapshot the pending changes at the moment of save
     const changesToSave = { ...pendingChanges };
-    const savedFields: string[] = [];
-    const failedFields: string[] = [];
+    if (Object.keys(changesToSave).length === 0) return;
 
-    // Save changes sequentially to handle version increments properly
+    setIsSaving(true);
+    let currentVersion = currentObject.version;
+    let successCount = 0;
+
+    // Save changes sequentially with updated version after each save
     for (const [field, value] of Object.entries(changesToSave)) {
       try {
-        await updateObjectMutation.mutateAsync({
-          id: object._id.toString(),
-          version: object.version,
+        const result = await updateObjectMutation.mutateAsync({
+          id: currentObject._id.toString(),
+          version: currentVersion,
           field,
           value,
         });
-        savedFields.push(field);
-        // Clear successfully saved field from pending
+        // Update version from response for next iteration
+        if (result && typeof result.version === 'number') {
+          currentVersion = result.version;
+        }
+        successCount++;
+        // Clear this field from pending
         setPendingChanges(prev => {
           const { [field]: _, ...rest } = prev;
           return rest;
         });
       } catch (error) {
         console.error(`Failed to save field ${field}:`, error);
-        failedFields.push(field);
-        // Don't clear failed fields - they remain in pendingChanges
+        // Stop on error to avoid cascading failures
+        break;
       }
     }
 
-    // Only update lastSaved if at least one field was saved successfully
-    if (savedFields.length > 0) {
+    setIsSaving(false);
+    if (successCount > 0) {
       setLastSaved(new Date());
     }
-  }, [object, id, pendingChanges, updateObjectMutation]);
+  }, [id, pendingChanges, updateObjectMutation, queryClient]);
+
+  // Schedule autosave - debounces all changes together
+  const scheduleAutoSave = useCallback(() => {
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+    saveTimeoutRef.current = setTimeout(() => {
+      saveAllPendingChanges();
+    }, 2000);
+  }, [saveAllPendingChanges]);
+
+  // Handle field update - updates UI immediately, schedules save if autosave enabled
+  const handleFieldUpdate = useCallback((field: string, value: any) => {
+    if (!object || !id) return;
+
+    // Update pendingChanges immediately for instant visual feedback
+    setPendingChanges(prev => ({ ...prev, [field]: value }));
+
+    if (autoSave) {
+      scheduleAutoSave();
+    }
+  }, [object, id, autoSave, scheduleAutoSave]);
+
+  // Manual save - saves immediately
+  const handleManualSave = useCallback(() => {
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+    saveAllPendingChanges();
+  }, [saveAllPendingChanges]);
 
   const hasPendingChanges = Object.keys(pendingChanges).length > 0;
 

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -1,7 +1,9 @@
+import { useState, useEffect, useRef } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import type { Object, ObjectFormData } from "@/types/objects";
 import { Button } from "@/components/ui/button";
-import { History, Trash2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { History, Trash2, Pencil, Check, X } from "lucide-react";
 import { SmartBackButton } from "@/components/SmartBackButton";
 import {
   useDeleteObject,
@@ -13,7 +15,93 @@ import { RelationshipsPanel } from "@/components/RelationshipsPanel";
 import { MetadataDisplay } from "@/components/MetadataDisplay";
 import { ObjectAudioPlayer } from "@/components/ObjectAudioPlayer";
 import { ObjectTranscriptPanel } from "@/components/ObjectTranscriptPanel";
-import { ObjectId } from "bson";
+import { Markdown } from "@/components/Markdown";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { EmojiPickerButton } from "@/components/ui/emoji-picker";
+
+// Inline editable title component
+function EditableTitle({
+  icon,
+  name,
+  onIconChange,
+  onNameChange,
+}: {
+  icon: any;
+  name: string;
+  onIconChange: (icon: any) => void;
+  onNameChange: (name: string) => void;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState(name);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setEditName(name);
+  }, [name]);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  const handleSave = () => {
+    if (editName.trim() !== name) {
+      onNameChange(editName.trim());
+    }
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditName(name);
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      handleSave();
+    } else if (e.key === "Escape") {
+      handleCancel();
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-3 group">
+      <EmojiPickerButton
+        value={icon}
+        onChange={onIconChange}
+        className="text-4xl"
+      />
+      {isEditing ? (
+        <div className="flex items-center gap-2 flex-1">
+          <Input
+            ref={inputRef}
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={handleSave}
+            className="text-2xl font-bold h-auto py-1"
+          />
+          <Button variant="ghost" size="sm" onClick={handleSave}>
+            <Check className="w-4 h-4" />
+          </Button>
+          <Button variant="ghost" size="sm" onClick={handleCancel}>
+            <X className="w-4 h-4" />
+          </Button>
+        </div>
+      ) : (
+        <h1 
+          className="text-2xl font-bold cursor-pointer hover:text-primary transition-colors flex items-center gap-2"
+          onClick={() => setIsEditing(true)}
+        >
+          {name || "Untitled Object"}
+          <Pencil className="w-4 h-4 opacity-0 group-hover:opacity-50 transition-opacity" />
+        </h1>
+      )}
+    </div>
+  );
+}
 
 const ObjectDetailPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -95,7 +183,7 @@ const ObjectDetailPage = () => {
 
   return (
     <div className="max-w-7xl mx-auto space-y-6">
-      {/* Header */}
+      {/* Header with navigation and actions */}
       <div className="flex items-center justify-between">
         <SmartBackButton defaultPath="/objects" />
         <div className="flex items-center gap-2">
@@ -120,30 +208,34 @@ const ObjectDetailPage = () => {
         </div>
       </div>
 
-      {/* Main content: Player+Summary on left, Transcript on right */}
-      {hasTimeRanges && (
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Left column: Player + Summary */}
-          <div className="space-y-4">
-            <ObjectAudioPlayer timeRange={object.timeRanges[0]} />
+      {/* Title: Icon + Name (editable inline) */}
+      <EditableTitle
+        icon={object.icon}
+        name={object.name || ""}
+        onIconChange={(icon) => handleFieldUpdate("icon", icon)}
+        onNameChange={(name) => handleFieldUpdate("name", name)}
+      />
 
-            {/* Summary Panel */}
-            <div className="border rounded-lg p-4 bg-muted/30">
-              <h3 className="text-sm font-semibold text-muted-foreground mb-3">Summary</h3>
-              {hasSummary ? (
-                <div className="prose prose-sm max-w-none max-h-[300px] overflow-y-auto">
-                  <div className="whitespace-pre-wrap text-sm">
-                    {object.summaries[0].text}
-                  </div>
+      {/* Main content: Summary on left, Player+Transcript on right */}
+      {hasTimeRanges && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* Left column: Summary */}
+          <div className="border rounded-lg p-4 bg-muted/30">
+            <h3 className="text-sm font-semibold text-muted-foreground mb-3">Summary</h3>
+            {hasSummary ? (
+              <ScrollArea className="h-[500px]">
+                <div className="prose prose-sm max-w-none pr-3">
+                  <Markdown>{object.summaries[0].text}</Markdown>
                 </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">No summary available</p>
-              )}
-            </div>
+              </ScrollArea>
+            ) : (
+              <p className="text-sm text-muted-foreground">No summary available</p>
+            )}
           </div>
 
-          {/* Right column: Transcript (bigger - 2 cols) */}
-          <div className="lg:col-span-2">
+          {/* Right column: Player on top, Transcript below */}
+          <div className="space-y-4">
+            <ObjectAudioPlayer timeRange={object.timeRanges[0]} />
             <ObjectTranscriptPanel timeRange={object.timeRanges[0]} />
           </div>
         </div>
@@ -161,12 +253,14 @@ const ObjectDetailPage = () => {
                 handleFieldUpdate(field, value);
               }
             }}
+            hideSummary
+            hideIconName
           />
         </div>
 
         {/* Side panel - Metadata & Relationships */}
         <div className="space-y-4">
-          <MetadataDisplay object={object} />
+          <MetadataDisplay object={object} hideObjectType />
           <div className="border rounded-lg p-4">
             <RelationshipsPanel object={object} />
           </div>

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -536,6 +536,7 @@ const ObjectDetailPage = () => {
             hideSummary
             hideIconName
             hideDetails
+            compact
           />
         </div>
       </div>

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -12,7 +12,6 @@ import {
   Check, 
   X, 
   Tag, 
-  Link2,
   Handshake,
   Users,
   MessageSquare,
@@ -28,7 +27,6 @@ import {
   useDeleteObject,
   useObject,
   useUpdateObject,
-  getRelationships,
 } from "@/hooks/useObjectQueries";
 import { ObjectForm } from "@/components/ObjectForm";
 import { RelationshipsPanel } from "@/components/RelationshipsPanel";
@@ -173,9 +171,6 @@ const ObjectDetailPage = () => {
   const updateObjectMutation = useUpdateObject();
   const deleteObjectMutation = useDeleteObject();
   
-  // Fetch relationships for this object
-  const { data: relationships = [] } = getRelationships(object?._id);
-  
   // State for time range editing from metadata display
   const [editingTimeRangeIndex, setEditingTimeRangeIndex] = useState<number | null>(null);
   
@@ -191,6 +186,7 @@ const ObjectDetailPage = () => {
   const [pendingChanges, setPendingChanges] = useState<Record<string, any>>({});
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
   const [, forceUpdate] = useState(0); // For relative time updates
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   
   // Update relative time every minute
   useEffect(() => {
@@ -198,10 +194,17 @@ const ObjectDetailPage = () => {
     return () => clearInterval(interval);
   }, []);
 
-  const handleFieldUpdate = useCallback((field: string, value: any) => {
+  // Throttled save function - saves after 2 seconds of inactivity
+  const throttledSave = useCallback((field: string, value: any) => {
     if (!object || !id) return;
 
-    if (autoSave) {
+    // Clear existing timeout
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+
+    // Set new timeout for 2 seconds
+    saveTimeoutRef.current = setTimeout(() => {
       updateObjectMutation.mutate({
         id: object._id.toString(),
         version: object.version,
@@ -210,11 +213,29 @@ const ObjectDetailPage = () => {
       }, {
         onSuccess: () => setLastSaved(new Date()),
       });
+    }, 2000);
+  }, [object, id, updateObjectMutation]);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleFieldUpdate = useCallback((field: string, value: any) => {
+    if (!object || !id) return;
+
+    if (autoSave) {
+      // Use throttled save with 2 second delay
+      throttledSave(field, value);
     } else {
       // Accumulate changes when autosave is off
       setPendingChanges(prev => ({ ...prev, [field]: value }));
     }
-  }, [object, id, autoSave, updateObjectMutation]);
+  }, [object, id, autoSave, throttledSave]);
 
   // Manual save function
   const handleManualSave = useCallback(() => {
@@ -232,6 +253,8 @@ const ObjectDetailPage = () => {
     setPendingChanges({});
     setLastSaved(new Date());
   }, [object, id, pendingChanges, updateObjectMutation]);
+
+  const hasPendingChanges = Object.keys(pendingChanges).length > 0;
 
   // Convert Object to ObjectFormData for the form
   const formObject: ObjectFormData = object
@@ -301,28 +324,23 @@ const ObjectDetailPage = () => {
       {/* Header with navigation and actions */}
       <div className="flex items-center justify-between">
         <SmartBackButton defaultPath="/objects" />
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2">
           {/* Status indicator */}
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <div className="flex items-center gap-1 text-xs text-muted-foreground">
             {updateObjectMutation.isPending ? (
               <span className="text-primary">Saving...</span>
-            ) : Object.keys(pendingChanges).length > 0 ? (
-              <span className="text-amber-600">Unsaved changes</span>
-            ) : lastSaved ? (
-              <span className="flex items-center gap-1">
-                <Clock className="w-3 h-3" />
-                Saved {formatRelativeTime(lastSaved)}
+            ) : hasPendingChanges ? (
+              <span className="text-amber-600">Unsaved</span>
+            ) : (
+              <span className="flex items-center gap-1 text-green-600">
+                <Check className="w-3 h-3" />
+                Saved
               </span>
-            ) : object?.updatedAt ? (
-              <span className="flex items-center gap-1">
-                <Clock className="w-3 h-3" />
-                Updated {formatRelativeTime(object.updatedAt)}
-              </span>
-            ) : null}
+            )}
           </div>
           
           {/* Autosave toggle */}
-          <div className="flex items-center gap-1.5 text-xs">
+          <div className="flex items-center gap-1 text-xs">
             <Switch
               checked={autoSave}
               onCheckedChange={setAutoSave}
@@ -331,13 +349,13 @@ const ObjectDetailPage = () => {
             <span className="text-muted-foreground">Auto</span>
           </div>
           
-          {/* Manual save button (shown when autosave is off and there are pending changes) */}
-          {!autoSave && Object.keys(pendingChanges).length > 0 && (
+          {/* Save button (shown when autosave is off) */}
+          {!autoSave && (
             <Button 
-              variant="default" 
+              variant={hasPendingChanges ? "default" : "outline"}
               size="sm" 
               onClick={handleManualSave}
-              disabled={updateObjectMutation.isPending}
+              disabled={!hasPendingChanges || updateObjectMutation.isPending}
             >
               <Save className="w-4 h-4 mr-1" />
               Save
@@ -346,8 +364,8 @@ const ObjectDetailPage = () => {
           
           <Button variant="outline" size="sm" asChild>
             <Link to={`/objects/${id}/history`}>
-              <History className="w-4 h-4 mr-2" />
-              History
+              <History className="w-4 h-4 mr-1" />
+              v{object.version}
             </Link>
           </Button>
           <Button
@@ -356,8 +374,7 @@ const ObjectDetailPage = () => {
             onClick={handleDelete}
             disabled={deleteObjectMutation.isPending}
           >
-            <Trash2 className="w-4 h-4 mr-2" />
-            {deleteObjectMutation.isPending ? "Deleting..." : "Delete"}
+            <Trash2 className="w-4 h-4" />
           </Button>
         </div>
       </div>
@@ -408,22 +425,14 @@ const ObjectDetailPage = () => {
               )}
             </div>
           )}
-          
-          {/* Relationships count */}
-          {relationships.length > 0 && (
-            <div className="flex items-center gap-1 text-muted-foreground">
-              <Link2 className="w-3 h-3" />
-              <span>{relationships.length}</span>
-            </div>
-          )}
         </div>
       </div>
 
       {/* Row 1: Summary (left) + Player/Transcript (right) - flexible height */}
       {hasTimeRanges && (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          {/* Summary - flexible height */}
-          <div className="border rounded-lg p-4 bg-muted/30 min-h-[300px] max-h-[600px] flex flex-col">
+          {/* Summary - flexible height, expands for long content */}
+          <div className="border rounded-lg p-4 bg-muted/30 min-h-[400px] max-h-[800px] flex flex-col">
             <h3 className="text-sm font-semibold text-muted-foreground mb-3 flex-shrink-0">Summary</h3>
             {hasSummary ? (
               <>
@@ -463,8 +472,8 @@ const ObjectDetailPage = () => {
             )}
           </div>
 
-          {/* Player + Transcript - flexible height */}
-          <ObjectPlayerTranscript timeRange={object.timeRanges[0]} minHeight={300} maxHeight={600} />
+          {/* Player + Transcript - flexible height, expands for long content */}
+          <ObjectPlayerTranscript timeRange={object.timeRanges[0]} minHeight={400} maxHeight={800} />
         </div>
       )}
 
@@ -524,8 +533,8 @@ const ObjectDetailPage = () => {
           )}
         </div>
 
-        {/* Relationships - expandable */}
-        <div className="border rounded-lg p-4 min-h-[200px] max-h-[400px] flex flex-col overflow-hidden">
+        {/* Relationships - scrollable */}
+        <div className="border rounded-lg p-4 min-h-[200px] max-h-[500px] overflow-y-auto">
           <RelationshipsPanel object={object} />
         </div>
       </div>

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -260,7 +260,7 @@ const ObjectDetailPage = () => {
     }
     saveTimeoutRef.current = setTimeout(() => {
       saveAllPendingChanges();
-    }, 2000);
+    }, 500);
   }, [saveAllPendingChanges]);
 
   // Handle field update - updates UI immediately, schedules save if autosave enabled
@@ -291,13 +291,16 @@ const ObjectDetailPage = () => {
     ? {
       ...object,
       ...pendingChanges, // Apply pending changes immediately for instant UI feedback
-      relationship: object.relationship
-        ? {
-          object: object.relationship.object,
-          subject: object.relationship.subject,
-          symmetrical: object.relationship.symmetrical,
-        }
-        : undefined,
+      // Use pending relationship changes if present, otherwise use server's relationship
+      relationship: pendingChanges.relationship !== undefined
+        ? pendingChanges.relationship
+        : object.relationship
+          ? {
+            object: object.relationship.object,
+            subject: object.relationship.subject,
+            symmetrical: object.relationship.symmetrical,
+          }
+          : undefined,
     }
     : {} as ObjectFormData;
 

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -320,43 +320,44 @@ const ObjectDetailPage = () => {
   const TypeIcon = typeInfo.icon;
 
   return (
-    <div className="max-w-7xl mx-auto space-y-6">
-      {/* Header with navigation and actions */}
-      <div className="flex items-center justify-between">
-        <SmartBackButton defaultPath="/objects" />
-        <div className="flex items-center gap-2">
-          {/* Status indicator */}
-          <div className="flex items-center gap-1 text-xs text-muted-foreground">
-            {updateObjectMutation.isPending ? (
-              <span className="text-primary">Saving...</span>
-            ) : hasPendingChanges ? (
-              <span className="text-amber-600">Unsaved</span>
-            ) : (
-              <span className="flex items-center gap-1 text-green-600">
-                <Check className="w-3 h-3" />
-                Saved
-              </span>
-            )}
-          </div>
-          
-          {/* Autosave toggle */}
-          <div className="flex items-center gap-1 text-xs">
-            <Switch
-              checked={autoSave}
-              onCheckedChange={setAutoSave}
-              className="h-4 w-7"
-            />
-            <span className="text-muted-foreground">Auto</span>
-          </div>
-          
-          {/* Save button (shown when autosave is off) */}
-          {!autoSave && (
-            <Button 
-              variant={hasPendingChanges ? "default" : "outline"}
-              size="sm" 
-              onClick={handleManualSave}
-              disabled={!hasPendingChanges || updateObjectMutation.isPending}
-            >
+    <div className="max-w-7xl mx-auto space-y-4">
+      {/* Sticky Header with navigation and actions */}
+      <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-sm border-b pb-3 -mx-4 px-4 pt-2">
+        <div className="flex items-center justify-between">
+          <SmartBackButton defaultPath="/objects" />
+          <div className="flex items-center gap-3">
+            {/* Status indicator */}
+            <div className="flex items-center gap-1.5 text-sm">
+              {updateObjectMutation.isPending ? (
+                <span className="text-primary font-medium">Saving...</span>
+              ) : hasPendingChanges ? (
+                <span className="text-amber-600 font-medium">● Unsaved</span>
+              ) : (
+                <span className="flex items-center gap-1 text-green-600 font-medium">
+                  <Check className="w-4 h-4" />
+                  Saved
+                </span>
+              )}
+            </div>
+            
+            {/* Autosave toggle */}
+            <div className="flex items-center gap-1.5 text-sm">
+              <Switch
+                checked={autoSave}
+                onCheckedChange={setAutoSave}
+                className="h-4 w-7"
+              />
+              <span className="text-muted-foreground">Auto</span>
+            </div>
+            
+            {/* Save button (shown when autosave is off) */}
+            {!autoSave && (
+              <Button 
+                variant={hasPendingChanges ? "default" : "outline"}
+                size="sm" 
+                onClick={handleManualSave}
+                disabled={!hasPendingChanges || updateObjectMutation.isPending}
+              >
               <Save className="w-4 h-4 mr-1" />
               Save
             </Button>
@@ -377,6 +378,7 @@ const ObjectDetailPage = () => {
           >
             <Trash2 className="w-4 h-4" />
           </Button>
+        </div>
         </div>
       </div>
 
@@ -475,15 +477,15 @@ const ObjectDetailPage = () => {
         </div>
       )}
 
-      {/* Row 2: Relationships (left) | Object Type (right) */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+      {/* Row 2: Relationships (left) | Object Type (right) - equal height */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3" style={{ gridAutoRows: '1fr' }}>
         {/* Relationships */}
-        <div className="border rounded-lg p-3 max-h-[250px] overflow-y-auto">
-          <RelationshipsPanel object={object} compact />
+        <div className="border rounded-lg p-3 min-h-[200px] max-h-[280px] overflow-y-auto flex flex-col">
+          <RelationshipsPanel object={object} />
         </div>
 
         {/* Object Type - with labels, clickable */}
-        <div className="border rounded-lg p-3">
+        <div className="border rounded-lg p-3 min-h-[200px] max-h-[280px] overflow-y-auto">
           <ObjectForm
             object={formObject}
             onUpdate={async (updates) => {
@@ -495,7 +497,6 @@ const ObjectDetailPage = () => {
             hideSummary
             hideIconName
             hideDetails
-            compact
           />
         </div>
       </div>

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -186,7 +186,6 @@ const ObjectDetailPage = () => {
   const [pendingChanges, setPendingChanges] = useState<Record<string, any>>({});
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
   const [, forceUpdate] = useState(0); // For relative time updates
-  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   
   // Update relative time every minute
   useEffect(() => {
@@ -194,17 +193,21 @@ const ObjectDetailPage = () => {
     return () => clearInterval(interval);
   }, []);
 
-  // Throttled save function - saves after 2 seconds of inactivity
+  // Per-field timeouts map for throttled saves
+  const fieldTimeoutsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  // Throttled save function - saves after 2 seconds of inactivity per field
   const throttledSave = useCallback((field: string, value: any) => {
     if (!object || !id) return;
 
-    // Clear existing timeout
-    if (saveTimeoutRef.current) {
-      clearTimeout(saveTimeoutRef.current);
+    // Clear existing timeout for THIS field only
+    const existingTimeout = fieldTimeoutsRef.current.get(field);
+    if (existingTimeout) {
+      clearTimeout(existingTimeout);
     }
 
-    // Set new timeout for 2 seconds
-    saveTimeoutRef.current = setTimeout(() => {
+    // Set new timeout for 2 seconds for THIS field
+    const timeout = setTimeout(() => {
       updateObjectMutation.mutate({
         id: object._id.toString(),
         version: object.version,
@@ -218,17 +221,24 @@ const ObjectDetailPage = () => {
             const { [field]: _, ...rest } = prev;
             return rest;
           });
+          // Remove from timeouts map
+          fieldTimeoutsRef.current.delete(field);
+        },
+        onError: () => {
+          // Remove from timeouts map on error too
+          fieldTimeoutsRef.current.delete(field);
         },
       });
     }, 2000);
+
+    fieldTimeoutsRef.current.set(field, timeout);
   }, [object, id, updateObjectMutation]);
 
-  // Cleanup timeout on unmount
+  // Cleanup all timeouts on unmount
   useEffect(() => {
     return () => {
-      if (saveTimeoutRef.current) {
-        clearTimeout(saveTimeoutRef.current);
-      }
+      fieldTimeoutsRef.current.forEach((timeout) => clearTimeout(timeout));
+      fieldTimeoutsRef.current.clear();
     };
   }, []);
 
@@ -245,21 +255,40 @@ const ObjectDetailPage = () => {
     // When autosave is off, changes stay in pendingChanges until manual save
   }, [object, id, autoSave, throttledSave]);
 
-  // Manual save function
-  const handleManualSave = useCallback(() => {
+  // Manual save function - saves all pending changes sequentially
+  const handleManualSave = useCallback(async () => {
     if (!object || !id || Object.keys(pendingChanges).length === 0) return;
 
-    // Save all pending changes
-    for (const [field, value] of Object.entries(pendingChanges)) {
-      updateObjectMutation.mutate({
-        id: object._id.toString(),
-        version: object.version,
-        field,
-        value,
-      });
+    const changesToSave = { ...pendingChanges };
+    const savedFields: string[] = [];
+    const failedFields: string[] = [];
+
+    // Save changes sequentially to handle version increments properly
+    for (const [field, value] of Object.entries(changesToSave)) {
+      try {
+        await updateObjectMutation.mutateAsync({
+          id: object._id.toString(),
+          version: object.version,
+          field,
+          value,
+        });
+        savedFields.push(field);
+        // Clear successfully saved field from pending
+        setPendingChanges(prev => {
+          const { [field]: _, ...rest } = prev;
+          return rest;
+        });
+      } catch (error) {
+        console.error(`Failed to save field ${field}:`, error);
+        failedFields.push(field);
+        // Don't clear failed fields - they remain in pendingChanges
+      }
     }
-    setPendingChanges({});
-    setLastSaved(new Date());
+
+    // Only update lastSaved if at least one field was saved successfully
+    if (savedFields.length > 0) {
+      setLastSaved(new Date());
+    }
   }, [object, id, pendingChanges, updateObjectMutation]);
 
   const hasPendingChanges = Object.keys(pendingChanges).length > 0;

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -43,6 +43,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { formatTime } from "@/lib/formatTime";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { EmojiPickerButton } from "@/components/ui/emoji-picker";
 
@@ -179,6 +181,10 @@ const ObjectDetailPage = () => {
   
   // State for summary details dialog
   const [selectedSummary, setSelectedSummary] = useState<any | null>(null);
+  
+  // State for editing details
+  const [isEditingDetails, setIsEditingDetails] = useState(false);
+  const [editingDetailsValue, setEditingDetailsValue] = useState("");
   
   // Autosave settings and status
   const { autoSave, setAutoSave } = useSettingsStore();
@@ -365,44 +371,59 @@ const ObjectDetailPage = () => {
           onNameChange={(name) => handleFieldUpdate("name", name)}
         />
         
-        {/* Object Type, Tags and Relationships */}
-        <div className="flex items-center gap-3 flex-shrink-0 flex-wrap justify-end">
+        {/* Object Type, Duration, Date, Tags and Relationships */}
+        <div className="flex items-center gap-2 flex-shrink-0 flex-wrap justify-end text-xs">
           {/* Object Type Badge */}
-          <div className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium ${typeInfo.color}`}>
-            <TypeIcon className="w-3.5 h-3.5" />
+          <div className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md font-medium ${typeInfo.color}`}>
+            <TypeIcon className="w-3 h-3" />
             <span>{typeInfo.type}</span>
           </div>
+          
+          {/* Duration */}
+          {hasTimeRanges && object.timeRanges[0].end && (
+            <div className="flex items-center gap-1 text-muted-foreground">
+              <Clock className="w-3 h-3" />
+              <span>{Math.round((new Date(object.timeRanges[0].end).getTime() - new Date(object.timeRanges[0].start).getTime()) / 60000)}m</span>
+            </div>
+          )}
+          
+          {/* Date */}
+          {hasTimeRanges && (
+            <div className="text-muted-foreground">
+              {formatTime(new Date(object.timeRanges[0].start), "gregorian-local-natural")}
+            </div>
+          )}
           
           {/* Aliases as tags */}
           {object.aliases && object.aliases.length > 0 && (
             <div className="flex items-center gap-1">
-              <Tag className="w-3.5 h-3.5 text-muted-foreground" />
-              {object.aliases.slice(0, 3).map((alias, idx) => (
-                <Badge key={idx} variant="secondary" className="text-xs">
+              <Tag className="w-3 h-3 text-muted-foreground" />
+              {object.aliases.slice(0, 2).map((alias, idx) => (
+                <Badge key={idx} variant="secondary" className="text-xs py-0">
                   {alias}
                 </Badge>
               ))}
-              {object.aliases.length > 3 && (
-                <span className="text-xs text-muted-foreground">+{object.aliases.length - 3}</span>
+              {object.aliases.length > 2 && (
+                <span className="text-muted-foreground">+{object.aliases.length - 2}</span>
               )}
             </div>
           )}
           
           {/* Relationships count */}
           {relationships.length > 0 && (
-            <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
-              <Link2 className="w-3.5 h-3.5" />
+            <div className="flex items-center gap-1 text-muted-foreground">
+              <Link2 className="w-3 h-3" />
               <span>{relationships.length}</span>
             </div>
           )}
         </div>
       </div>
 
-      {/* Row 1: Summary (left) + Player/Transcript (right) - same height */}
+      {/* Row 1: Summary (left) + Player/Transcript (right) - flexible height */}
       {hasTimeRanges && (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          {/* Summary - matches transcript height */}
-          <div className="border rounded-lg p-4 bg-muted/30 h-[500px] flex flex-col">
+          {/* Summary - flexible height */}
+          <div className="border rounded-lg p-4 bg-muted/30 min-h-[300px] max-h-[600px] flex flex-col">
             <h3 className="text-sm font-semibold text-muted-foreground mb-3 flex-shrink-0">Summary</h3>
             {hasSummary ? (
               <>
@@ -442,25 +463,65 @@ const ObjectDetailPage = () => {
             )}
           </div>
 
-          {/* Player + Transcript */}
-          <ObjectPlayerTranscript timeRange={object.timeRanges[0]} height={500} />
+          {/* Player + Transcript - flexible height */}
+          <ObjectPlayerTranscript timeRange={object.timeRanges[0]} minHeight={300} maxHeight={600} />
         </div>
       )}
 
       {/* Row 2: Details (left) + Relationships (right) */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Details - expandable */}
+        {/* Details - editable */}
         <div className="border rounded-lg p-4 bg-muted/30 min-h-[200px] max-h-[400px] flex flex-col">
-          <h3 className="text-sm font-semibold text-muted-foreground mb-3 flex-shrink-0">Details</h3>
-          <ScrollArea className="flex-1 [&>[data-radix-scroll-area-viewport]]:!overflow-y-scroll">
-            <div className="prose prose-sm max-w-none pr-3">
-              {object.details ? (
-                <Markdown>{object.details}</Markdown>
-              ) : (
-                <p className="text-muted-foreground text-sm">No details available</p>
+          <div className="flex items-center justify-between mb-3 flex-shrink-0">
+            <h3 className="text-sm font-semibold text-muted-foreground">Details</h3>
+            <div className="flex items-center gap-1">
+              <Button
+                variant={isEditingDetails ? "default" : "ghost"}
+                size="sm"
+                className="h-6 px-2 text-xs"
+                onClick={() => {
+                  if (!isEditingDetails) {
+                    setEditingDetailsValue(object.details || "");
+                  }
+                  setIsEditingDetails(!isEditingDetails);
+                }}
+              >
+                {isEditingDetails ? "Preview" : "Edit"}
+              </Button>
+              {isEditingDetails && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-2 text-xs"
+                  onClick={() => {
+                    handleFieldUpdate("details", editingDetailsValue);
+                    setIsEditingDetails(false);
+                  }}
+                >
+                  <Check className="w-3 h-3 mr-1" />
+                  Save
+                </Button>
               )}
             </div>
-          </ScrollArea>
+          </div>
+          {isEditingDetails ? (
+            <Textarea
+              value={editingDetailsValue}
+              onChange={(e) => setEditingDetailsValue(e.target.value)}
+              placeholder="Add details about this object..."
+              className="flex-1 min-h-[150px] resize-none font-mono text-sm"
+            />
+          ) : (
+            <ScrollArea className="flex-1 [&>[data-radix-scroll-area-viewport]]:!overflow-y-scroll">
+              <div className="prose prose-sm max-w-none pr-3">
+                {object.details ? (
+                  <Markdown>{object.details}</Markdown>
+                ) : (
+                  <p className="text-muted-foreground text-sm">No details available. Click Edit to add.</p>
+                )}
+              </div>
+            </ScrollArea>
+          )}
         </div>
 
         {/* Relationships - expandable */}

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -475,15 +475,15 @@ const ObjectDetailPage = () => {
         </div>
       )}
 
-      {/* Row 2: Relationships (left) | Object Type (right, half) */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      {/* Row 2: Relationships (left) | Object Type (right) */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
         {/* Relationships */}
-        <div className="border rounded-lg p-4 min-h-[180px] max-h-[300px] overflow-y-auto">
+        <div className="border rounded-lg p-3 max-h-[250px] overflow-y-auto">
           <RelationshipsPanel object={object} compact />
         </div>
 
         {/* Object Type - with labels, clickable */}
-        <div className="border rounded-lg p-4">
+        <div className="border rounded-lg p-3">
           <ObjectForm
             object={formObject}
             onUpdate={async (updates) => {
@@ -495,86 +495,116 @@ const ObjectDetailPage = () => {
             hideSummary
             hideIconName
             hideDetails
+            compact
           />
         </div>
       </div>
 
-      {/* Row 3: Time Information (left) | Metadata (right) */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        {/* Time Information */}
-        <MetadataDisplay 
-          object={object} 
-          hideObjectType
-          hideMetadata
-          onEditTimeRanges={hasTimeRanges ? () => setEditingTimeRangeIndex(0) : undefined}
-        />
-
-        {/* Metadata */}
-        <div className="border rounded-lg p-4 space-y-3">
-          <h3 className="text-sm font-semibold text-muted-foreground">Metadata</h3>
-          <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-            <div className="text-muted-foreground">Created:</div>
-            <div>{formatTime(object.createdAt, dateFormat)}</div>
-            <div className="text-muted-foreground">Updated:</div>
-            <div>{formatTime(object.updatedAt, dateFormat)}</div>
-            <div className="text-muted-foreground">Version:</div>
-            <div>{object.version}</div>
-          </div>
-        </div>
-      </div>
-
-      {/* Row 4: Details - full width */}
-      <div className="border rounded-lg p-4 bg-muted/30 min-h-[120px] max-h-[250px] flex flex-col">
-        <div className="flex items-center justify-between mb-3 flex-shrink-0">
-          <h3 className="text-sm font-semibold text-muted-foreground">Details</h3>
-          <div className="flex items-center gap-1">
-            <Button
-              variant={isEditingDetails ? "default" : "ghost"}
-              size="sm"
-              className="h-6 px-2 text-xs"
-              onClick={() => {
-                if (!isEditingDetails) {
-                  setEditingDetailsValue(object.details || "");
-                }
-                setIsEditingDetails(!isEditingDetails);
-              }}
-            >
-              {isEditingDetails ? "Preview" : "Edit"}
-            </Button>
-            {isEditingDetails && (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-6 px-2 text-xs"
-                onClick={() => {
-                  handleFieldUpdate("details", editingDetailsValue);
-                  setIsEditingDetails(false);
-                }}
-              >
-                <Check className="w-3 h-3 mr-1" />
-                Save
+      {/* Row 3: Time Info + Metadata + Details (3 columns) */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        {/* Time Information - compact inline */}
+        <div className="border rounded-lg p-3 space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xs font-semibold text-muted-foreground">Time Information</h3>
+            {hasTimeRanges && (
+              <Button variant="ghost" size="sm" className="h-5 px-1.5 text-xs" onClick={() => setEditingTimeRangeIndex(0)}>
+                <Pencil className="w-3 h-3" />
               </Button>
             )}
           </div>
+          <div className="text-xs space-y-1">
+            {hasTimeRanges && object.timeRanges?.[0] && (
+              <>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Started:</span>
+                  <span>{formatTime(object.timeRanges[0].start, dateFormat)}</span>
+                </div>
+                {object.timeRanges[0].end && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Ended:</span>
+                    <span>{formatTime(object.timeRanges[0].end, dateFormat)}</span>
+                  </div>
+                )}
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Duration:</span>
+                  <span className="font-medium">{Math.round((new Date(object.timeRanges[0].end || Date.now()).getTime() - new Date(object.timeRanges[0].start).getTime()) / 60000)}m</span>
+                </div>
+              </>
+            )}
+          </div>
         </div>
-        {isEditingDetails ? (
-          <Textarea
-            value={editingDetailsValue}
-            onChange={(e) => setEditingDetailsValue(e.target.value)}
-            placeholder="Add details about this object..."
-            className="flex-1 min-h-[80px] resize-none font-mono text-sm"
-          />
-        ) : (
-          <ScrollArea className="flex-1 [&>[data-radix-scroll-area-viewport]]:!overflow-y-scroll">
-            <div className="prose prose-sm max-w-none pr-3">
-              {object.details ? (
-                <Markdown>{object.details}</Markdown>
-              ) : (
-                <p className="text-muted-foreground text-sm">No details available. Click Edit to add.</p>
+
+        {/* Metadata - compact */}
+        <div className="border rounded-lg p-3 space-y-2">
+          <h3 className="text-xs font-semibold text-muted-foreground">Metadata</h3>
+          <div className="text-xs space-y-1">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Created:</span>
+              <span>{formatTime(object.createdAt, dateFormat)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Updated:</span>
+              <span>{formatTime(object.updatedAt, dateFormat)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Version:</span>
+              <span>{object.version}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Details - compact */}
+        <div className="border rounded-lg p-3 bg-muted/30 flex flex-col max-h-[150px]">
+          <div className="flex items-center justify-between mb-2 flex-shrink-0">
+            <h3 className="text-xs font-semibold text-muted-foreground">Details</h3>
+            <div className="flex items-center gap-1">
+              <Button
+                variant={isEditingDetails ? "default" : "ghost"}
+                size="sm"
+                className="h-5 px-1.5 text-xs"
+                onClick={() => {
+                  if (!isEditingDetails) {
+                    setEditingDetailsValue(object.details || "");
+                  }
+                  setIsEditingDetails(!isEditingDetails);
+                }}
+              >
+                {isEditingDetails ? "Preview" : "Edit"}
+              </Button>
+              {isEditingDetails && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-5 px-1.5 text-xs"
+                  onClick={() => {
+                    handleFieldUpdate("details", editingDetailsValue);
+                    setIsEditingDetails(false);
+                  }}
+                >
+                  <Check className="w-3 h-3" />
+                </Button>
               )}
             </div>
-          </ScrollArea>
-        )}
+          </div>
+          {isEditingDetails ? (
+            <Textarea
+              value={editingDetailsValue}
+              onChange={(e) => setEditingDetailsValue(e.target.value)}
+              placeholder="Add details..."
+              className="flex-1 min-h-[60px] resize-none font-mono text-xs"
+            />
+          ) : (
+            <ScrollArea className="flex-1 [&>[data-radix-scroll-area-viewport]]:!overflow-y-scroll">
+              <div className="prose prose-xs max-w-none pr-2 text-xs">
+                {object.details ? (
+                  <Markdown>{object.details}</Markdown>
+                ) : (
+                  <p className="text-muted-foreground text-xs">No details. Click Edit to add.</p>
+                )}
+              </div>
+            </ScrollArea>
+          )}
+        </div>
       </div>
 
       {/* Time Range Edit Dialog triggered from MetadataDisplay */}

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -1,10 +1,28 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import type { Object, ObjectFormData } from "@/types/objects";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import { History, Trash2, Pencil, Check, X, Tag, Link2 } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import { 
+  History, 
+  Trash2, 
+  Pencil, 
+  Check, 
+  X, 
+  Tag, 
+  Link2,
+  Handshake,
+  Users,
+  MessageSquare,
+  User,
+  Calendar,
+  Package,
+  Save,
+  Clock,
+} from "lucide-react";
+import { useSettingsStore } from "@/stores/settingsStore";
 import { SmartBackButton } from "@/components/SmartBackButton";
 import {
   useDeleteObject,
@@ -18,8 +36,48 @@ import { MetadataDisplay } from "@/components/MetadataDisplay";
 import { ObjectPlayerTranscript } from "@/components/ObjectPlayerTranscript";
 import { TimeRangeEditDialog } from "@/components/TimeRangeEditDialog";
 import { Markdown } from "@/components/Markdown";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { EmojiPickerButton } from "@/components/ui/emoji-picker";
+
+// Helper to format relative time (e.g., "2 minutes ago")
+function formatRelativeTime(date: Date | string | undefined): string {
+  if (!date) return "";
+  const d = typeof date === "string" ? new Date(date) : date;
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHours = Math.floor(diffMin / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffSec < 5) return "just now";
+  if (diffSec < 60) return `${diffSec}s ago`;
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return d.toLocaleDateString();
+}
+
+// Helper to get object type info
+function getObjectType(object: { isPromise?: boolean; isRelationship?: boolean; isConversation?: boolean; isPerson?: boolean; isEvent?: boolean }): {
+  type: string;
+  icon: React.ComponentType<{ className?: string }>;
+  color: string;
+} {
+  if (object.isPromise) return { type: "Promise", icon: Handshake, color: "bg-orange-100 text-orange-800 border border-orange-200" };
+  if (object.isRelationship) return { type: "Relationship", icon: Users, color: "bg-purple-100 text-purple-800 border border-purple-200" };
+  if (object.isConversation) return { type: "Conversation", icon: MessageSquare, color: "bg-cyan-100 text-cyan-800 border border-cyan-200" };
+  if (object.isPerson) return { type: "Person", icon: User, color: "bg-blue-100 text-blue-800 border border-blue-200" };
+  if (object.isEvent) return { type: "Event", icon: Calendar, color: "bg-green-100 text-green-800 border border-green-200" };
+  return { type: "Object", icon: Package, color: "bg-gray-100 text-gray-800 border border-gray-200" };
+}
 
 // Inline editable title component
 function EditableTitle({
@@ -69,36 +127,36 @@ function EditableTitle({
   };
 
   return (
-    <div className="flex items-center gap-3 group">
+    <div className="flex items-center gap-3 group flex-1 min-w-0">
       <EmojiPickerButton
         value={icon}
         onChange={onIconChange}
-        className="text-4xl"
+        className="text-4xl flex-shrink-0"
       />
       {isEditing ? (
-        <div className="flex items-center gap-2 flex-1">
+        <div className="flex items-center gap-2 flex-1 min-w-0">
           <Input
             ref={inputRef}
             value={editName}
             onChange={(e) => setEditName(e.target.value)}
             onKeyDown={handleKeyDown}
             onBlur={handleSave}
-            className="text-2xl font-bold h-auto py-1"
+            className="text-2xl font-bold h-auto py-1 flex-1"
           />
-          <Button variant="ghost" size="sm" onClick={handleSave}>
+          <Button variant="ghost" size="sm" onClick={handleSave} className="flex-shrink-0">
             <Check className="w-4 h-4" />
           </Button>
-          <Button variant="ghost" size="sm" onClick={handleCancel}>
+          <Button variant="ghost" size="sm" onClick={handleCancel} className="flex-shrink-0">
             <X className="w-4 h-4" />
           </Button>
         </div>
       ) : (
         <h1 
-          className="text-2xl font-bold cursor-pointer hover:text-primary transition-colors flex items-center gap-2"
+          className="text-2xl font-bold cursor-pointer hover:text-primary transition-colors flex items-center gap-2 flex-1 min-w-0"
           onClick={() => setIsEditing(true)}
         >
-          {name || "Untitled Object"}
-          <Pencil className="w-4 h-4 opacity-0 group-hover:opacity-50 transition-opacity" />
+          <span className="truncate">{name || "Untitled Object"}</span>
+          <Pencil className="w-4 h-4 opacity-0 group-hover:opacity-50 transition-opacity flex-shrink-0" />
         </h1>
       )}
     </div>
@@ -118,17 +176,56 @@ const ObjectDetailPage = () => {
   
   // State for time range editing from metadata display
   const [editingTimeRangeIndex, setEditingTimeRangeIndex] = useState<number | null>(null);
+  
+  // State for summary details dialog
+  const [selectedSummary, setSelectedSummary] = useState<any | null>(null);
+  
+  // Autosave settings and status
+  const { autoSave, setAutoSave } = useSettingsStore();
+  const [pendingChanges, setPendingChanges] = useState<Record<string, any>>({});
+  const [lastSaved, setLastSaved] = useState<Date | null>(null);
+  const [, forceUpdate] = useState(0); // For relative time updates
+  
+  // Update relative time every minute
+  useEffect(() => {
+    const interval = setInterval(() => forceUpdate(n => n + 1), 60000);
+    return () => clearInterval(interval);
+  }, []);
 
-  const handleFieldUpdate = (field: string, value: any) => {
+  const handleFieldUpdate = useCallback((field: string, value: any) => {
     if (!object || !id) return;
 
-    updateObjectMutation.mutate({
-      id: object._id.toString(),
-      version: object.version,
-      field,
-      value,
-    });
-  };
+    if (autoSave) {
+      updateObjectMutation.mutate({
+        id: object._id.toString(),
+        version: object.version,
+        field,
+        value,
+      }, {
+        onSuccess: () => setLastSaved(new Date()),
+      });
+    } else {
+      // Accumulate changes when autosave is off
+      setPendingChanges(prev => ({ ...prev, [field]: value }));
+    }
+  }, [object, id, autoSave, updateObjectMutation]);
+
+  // Manual save function
+  const handleManualSave = useCallback(() => {
+    if (!object || !id || Object.keys(pendingChanges).length === 0) return;
+
+    // Save all pending changes
+    for (const [field, value] of Object.entries(pendingChanges)) {
+      updateObjectMutation.mutate({
+        id: object._id.toString(),
+        version: object.version,
+        field,
+        value,
+      });
+    }
+    setPendingChanges({});
+    setLastSaved(new Date());
+  }, [object, id, pendingChanges, updateObjectMutation]);
 
   // Convert Object to ObjectFormData for the form
   const formObject: ObjectFormData = object
@@ -188,16 +285,59 @@ const ObjectDetailPage = () => {
 
   const hasTimeRanges = object.timeRanges && object.timeRanges.length > 0;
   const hasSummary = object.summaries && object.summaries.length > 0;
+  
+  // Get object type info for badge
+  const typeInfo = getObjectType(object);
+  const TypeIcon = typeInfo.icon;
 
   return (
     <div className="max-w-7xl mx-auto space-y-6">
       {/* Header with navigation and actions */}
       <div className="flex items-center justify-between">
         <SmartBackButton defaultPath="/objects" />
-        <div className="flex items-center gap-2">
-          {updateObjectMutation.isPending && (
-            <span className="text-xs text-muted-foreground">Saving...</span>
+        <div className="flex items-center gap-3">
+          {/* Status indicator */}
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            {updateObjectMutation.isPending ? (
+              <span className="text-primary">Saving...</span>
+            ) : Object.keys(pendingChanges).length > 0 ? (
+              <span className="text-amber-600">Unsaved changes</span>
+            ) : lastSaved ? (
+              <span className="flex items-center gap-1">
+                <Clock className="w-3 h-3" />
+                Saved {formatRelativeTime(lastSaved)}
+              </span>
+            ) : object?.updatedAt ? (
+              <span className="flex items-center gap-1">
+                <Clock className="w-3 h-3" />
+                Updated {formatRelativeTime(object.updatedAt)}
+              </span>
+            ) : null}
+          </div>
+          
+          {/* Autosave toggle */}
+          <div className="flex items-center gap-1.5 text-xs">
+            <Switch
+              checked={autoSave}
+              onCheckedChange={setAutoSave}
+              className="h-4 w-7"
+            />
+            <span className="text-muted-foreground">Auto</span>
+          </div>
+          
+          {/* Manual save button (shown when autosave is off and there are pending changes) */}
+          {!autoSave && Object.keys(pendingChanges).length > 0 && (
+            <Button 
+              variant="default" 
+              size="sm" 
+              onClick={handleManualSave}
+              disabled={updateObjectMutation.isPending}
+            >
+              <Save className="w-4 h-4 mr-1" />
+              Save
+            </Button>
           )}
+          
           <Button variant="outline" size="sm" asChild>
             <Link to={`/objects/${id}/history`}>
               <History className="w-4 h-4 mr-2" />
@@ -225,17 +365,26 @@ const ObjectDetailPage = () => {
           onNameChange={(name) => handleFieldUpdate("name", name)}
         />
         
-        {/* Tags and Relationships */}
-        <div className="flex flex-col items-end gap-2 flex-shrink-0">
+        {/* Object Type, Tags and Relationships */}
+        <div className="flex items-center gap-3 flex-shrink-0 flex-wrap justify-end">
+          {/* Object Type Badge */}
+          <div className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium ${typeInfo.color}`}>
+            <TypeIcon className="w-3.5 h-3.5" />
+            <span>{typeInfo.type}</span>
+          </div>
+          
           {/* Aliases as tags */}
           {object.aliases && object.aliases.length > 0 && (
-            <div className="flex flex-wrap gap-1 justify-end">
-              <Tag className="w-3.5 h-3.5 text-muted-foreground mr-1" />
-              {object.aliases.map((alias, idx) => (
+            <div className="flex items-center gap-1">
+              <Tag className="w-3.5 h-3.5 text-muted-foreground" />
+              {object.aliases.slice(0, 3).map((alias, idx) => (
                 <Badge key={idx} variant="secondary" className="text-xs">
                   {alias}
                 </Badge>
               ))}
+              {object.aliases.length > 3 && (
+                <span className="text-xs text-muted-foreground">+{object.aliases.length - 3}</span>
+              )}
             </div>
           )}
           
@@ -243,38 +392,94 @@ const ObjectDetailPage = () => {
           {relationships.length > 0 && (
             <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
               <Link2 className="w-3.5 h-3.5" />
-              <span>{relationships.length} relationship{relationships.length !== 1 ? 's' : ''}</span>
+              <span>{relationships.length}</span>
             </div>
           )}
         </div>
       </div>
 
-      {/* Main content: Summary on left, Player+Transcript on right */}
+      {/* Row 1: Summary (left) + Player/Transcript (right) - same height */}
       {hasTimeRanges && (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          {/* Left column: Summary */}
-          <div className="border rounded-lg p-4 bg-muted/30 h-[700px] flex flex-col">
+          {/* Summary - matches transcript height */}
+          <div className="border rounded-lg p-4 bg-muted/30 h-[500px] flex flex-col">
             <h3 className="text-sm font-semibold text-muted-foreground mb-3 flex-shrink-0">Summary</h3>
             {hasSummary ? (
-              <ScrollArea className="flex-1 [&>[data-radix-scroll-area-viewport]]:!overflow-y-scroll">
-                <div className="prose prose-sm max-w-none pr-3">
-                  <Markdown>{object.summaries[0].text}</Markdown>
+              <>
+                <ScrollArea className="flex-1 [&>[data-radix-scroll-area-viewport]]:!overflow-y-scroll">
+                  <div className="prose prose-sm max-w-none pr-3">
+                    <Markdown>{object.summaries[0].text}</Markdown>
+                  </div>
+                </ScrollArea>
+                {/* Summary metadata */}
+                <div className="flex-shrink-0 pt-3 mt-3 border-t flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                  {object.summaries[0].model && (
+                    <span className="flex items-center gap-1">
+                      <span className="font-medium">Model:</span>
+                      <span>{object.summaries[0].modelName || object.summaries[0].model}</span>
+                    </span>
+                  )}
+                  {object.summaries[0].date && (
+                    <span className="flex items-center gap-1">
+                      <span className="font-medium">Generated:</span>
+                      <span>{formatRelativeTime(object.summaries[0].date)}</span>
+                    </span>
+                  )}
+                  {(object.summaries[0].usage || object.summaries[0].prompt || object.summaries[0].jobId) && (
+                    <Button 
+                      variant="link" 
+                      size="sm"
+                      onClick={() => setSelectedSummary(object.summaries[0])}
+                      className="p-0 h-auto text-xs"
+                    >
+                      More details...
+                    </Button>
+                  )}
                 </div>
-              </ScrollArea>
+              </>
             ) : (
               <p className="text-sm text-muted-foreground">No summary available</p>
             )}
           </div>
 
-          {/* Right column: Combined Player + Transcript with independent scrolling */}
-          <ObjectPlayerTranscript timeRange={object.timeRanges[0]} />
+          {/* Player + Transcript */}
+          <ObjectPlayerTranscript timeRange={object.timeRanges[0]} height={500} />
         </div>
       )}
 
-      {/* Object Details Section */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Main Form - takes 2 columns */}
-        <div className="lg:col-span-2 border rounded-lg p-6">
+      {/* Row 2: Details (left) + Relationships (right) */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Details - expandable */}
+        <div className="border rounded-lg p-4 bg-muted/30 min-h-[200px] max-h-[400px] flex flex-col">
+          <h3 className="text-sm font-semibold text-muted-foreground mb-3 flex-shrink-0">Details</h3>
+          <ScrollArea className="flex-1 [&>[data-radix-scroll-area-viewport]]:!overflow-y-scroll">
+            <div className="prose prose-sm max-w-none pr-3">
+              {object.details ? (
+                <Markdown>{object.details}</Markdown>
+              ) : (
+                <p className="text-muted-foreground text-sm">No details available</p>
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+
+        {/* Relationships - expandable */}
+        <div className="border rounded-lg p-4 min-h-[200px] max-h-[400px] flex flex-col overflow-hidden">
+          <RelationshipsPanel object={object} />
+        </div>
+      </div>
+
+      {/* Row 3: Time Info + Metadata + Form fields */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {/* Time Information */}
+        <MetadataDisplay 
+          object={object} 
+          hideObjectType 
+          onEditTimeRanges={hasTimeRanges ? () => setEditingTimeRangeIndex(0) : undefined}
+        />
+
+        {/* Object Form - compact mode */}
+        <div className="border rounded-lg p-4 lg:col-span-2">
           <ObjectForm
             object={formObject}
             onUpdate={async (updates) => {
@@ -285,19 +490,8 @@ const ObjectDetailPage = () => {
             }}
             hideSummary
             hideIconName
+            hideDetails
           />
-        </div>
-
-        {/* Side panel - Metadata & Relationships */}
-        <div className="space-y-4">
-          <MetadataDisplay 
-            object={object} 
-            hideObjectType 
-            onEditTimeRanges={hasTimeRanges ? () => setEditingTimeRangeIndex(0) : undefined}
-          />
-          <div className="border rounded-lg p-4">
-            <RelationshipsPanel object={object} />
-          </div>
         </div>
       </div>
 
@@ -319,6 +513,78 @@ const ObjectDetailPage = () => {
           }}
         />
       )}
+
+      {/* Summary Details Dialog */}
+      <Dialog open={selectedSummary !== null} onOpenChange={(open) => !open && setSelectedSummary(null)}>
+        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Summary Details</DialogTitle>
+          </DialogHeader>
+          {selectedSummary && (
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <Label className="text-sm font-medium">Model</Label>
+                  <div className="mt-1 text-sm">
+                    {selectedSummary.model} {selectedSummary.modelName && `(${selectedSummary.modelName})`}
+                  </div>
+                </div>
+                <div>
+                  <Label className="text-sm font-medium">Generated</Label>
+                  <div className="mt-1 text-sm">
+                    {new Date(selectedSummary.date).toLocaleString([], {
+                      year: "numeric",
+                      month: "short",
+                      day: "numeric",
+                      hour: "2-digit",
+                      minute: "2-digit",
+                      second: "2-digit",
+                    })}
+                  </div>
+                </div>
+              </div>
+
+              {selectedSummary.usage && (
+                <div>
+                  <Label className="text-sm font-medium">Token Usage</Label>
+                  <div className="mt-2 grid grid-cols-3 gap-3 text-sm">
+                    <div className="p-2 bg-muted rounded">
+                      <div className="text-xs text-muted-foreground">Prompt</div>
+                      <div className="font-medium">{selectedSummary.usage.promptTokens?.toLocaleString()}</div>
+                    </div>
+                    <div className="p-2 bg-muted rounded">
+                      <div className="text-xs text-muted-foreground">Completion</div>
+                      <div className="font-medium">{selectedSummary.usage.completionTokens?.toLocaleString()}</div>
+                    </div>
+                    <div className="p-2 bg-muted rounded">
+                      <div className="text-xs text-muted-foreground">Total</div>
+                      <div className="font-medium">{selectedSummary.usage.totalTokens?.toLocaleString()}</div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {selectedSummary.prompt && (
+                <div>
+                  <Label className="text-sm font-medium">System Prompt</Label>
+                  <div className="mt-2 p-3 bg-muted rounded-md text-sm whitespace-pre-wrap max-h-[200px] overflow-y-auto font-mono">
+                    {selectedSummary.prompt}
+                  </div>
+                </div>
+              )}
+
+              {selectedSummary.jobId && (
+                <div>
+                  <Label className="text-sm font-medium">Job ID</Label>
+                  <div className="mt-1 text-sm font-mono text-muted-foreground">
+                    {selectedSummary.jobId}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -365,7 +365,8 @@ const ObjectDetailPage = () => {
           <Button variant="outline" size="sm" asChild>
             <Link to={`/objects/${id}/history`}>
               <History className="w-4 h-4 mr-1" />
-              v{object.version}
+              History
+              <span className="ml-1 text-muted-foreground">v{object.version}</span>
             </Link>
           </Button>
           <Button
@@ -379,8 +380,8 @@ const ObjectDetailPage = () => {
         </div>
       </div>
 
-      {/* Title row: Icon + Name on left, Tags + Relationships on right */}
-      <div className="flex items-start justify-between gap-4">
+      {/* Title row: Icon + Name on left, metadata on right - all on one line */}
+      <div className="flex items-center justify-between gap-4">
         <EditableTitle
           icon={object.icon}
           name={object.name || ""}
@@ -388,26 +389,23 @@ const ObjectDetailPage = () => {
           onNameChange={(name) => handleFieldUpdate("name", name)}
         />
         
-        {/* Object Type, Duration, Date, Tags and Relationships */}
-        <div className="flex items-center gap-2 flex-shrink-0 flex-wrap justify-end text-xs">
+        {/* Object Type, Date, Duration, Tags - aligned on one line */}
+        <div className="flex items-center gap-3 flex-shrink-0 text-xs">
           {/* Object Type Badge */}
           <div className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md font-medium ${typeInfo.color}`}>
             <TypeIcon className="w-3 h-3" />
             <span>{typeInfo.type}</span>
           </div>
           
-          {/* Duration */}
-          {hasTimeRanges && object.timeRanges[0].end && (
-            <div className="flex items-center gap-1 text-muted-foreground">
-              <Clock className="w-3 h-3" />
-              <span>{Math.round((new Date(object.timeRanges[0].end).getTime() - new Date(object.timeRanges[0].start).getTime()) / 60000)}m</span>
-            </div>
-          )}
-          
-          {/* Date */}
+          {/* Date and Duration together */}
           {hasTimeRanges && (
-            <div className="text-muted-foreground">
-              {formatTime(new Date(object.timeRanges[0].start), "gregorian-local-natural")}
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <span>{formatTime(new Date(object.timeRanges[0].start), "gregorian-local-natural")}</span>
+              {object.timeRanges[0].end && (
+                <span className="font-semibold text-foreground">
+                  {Math.round((new Date(object.timeRanges[0].end).getTime() - new Date(object.timeRanges[0].start).getTime()) / 60000)}m
+                </span>
+              )}
             </div>
           )}
           
@@ -477,79 +475,23 @@ const ObjectDetailPage = () => {
         </div>
       )}
 
-      {/* Row 2: Details (left) + Relationships (right) */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Details - editable */}
-        <div className="border rounded-lg p-4 bg-muted/30 min-h-[200px] max-h-[400px] flex flex-col">
-          <div className="flex items-center justify-between mb-3 flex-shrink-0">
-            <h3 className="text-sm font-semibold text-muted-foreground">Details</h3>
-            <div className="flex items-center gap-1">
-              <Button
-                variant={isEditingDetails ? "default" : "ghost"}
-                size="sm"
-                className="h-6 px-2 text-xs"
-                onClick={() => {
-                  if (!isEditingDetails) {
-                    setEditingDetailsValue(object.details || "");
-                  }
-                  setIsEditingDetails(!isEditingDetails);
-                }}
-              >
-                {isEditingDetails ? "Preview" : "Edit"}
-              </Button>
-              {isEditingDetails && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-6 px-2 text-xs"
-                  onClick={() => {
-                    handleFieldUpdate("details", editingDetailsValue);
-                    setIsEditingDetails(false);
-                  }}
-                >
-                  <Check className="w-3 h-3 mr-1" />
-                  Save
-                </Button>
-              )}
-            </div>
-          </div>
-          {isEditingDetails ? (
-            <Textarea
-              value={editingDetailsValue}
-              onChange={(e) => setEditingDetailsValue(e.target.value)}
-              placeholder="Add details about this object..."
-              className="flex-1 min-h-[150px] resize-none font-mono text-sm"
-            />
-          ) : (
-            <ScrollArea className="flex-1 [&>[data-radix-scroll-area-viewport]]:!overflow-y-scroll">
-              <div className="prose prose-sm max-w-none pr-3">
-                {object.details ? (
-                  <Markdown>{object.details}</Markdown>
-                ) : (
-                  <p className="text-muted-foreground text-sm">No details available. Click Edit to add.</p>
-                )}
-              </div>
-            </ScrollArea>
-          )}
+      {/* Row 2: Relationships + Time Info + Metadata (side by side) */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        {/* Relationships - compact */}
+        <div className="border rounded-lg p-3 min-h-[180px] max-h-[300px] overflow-y-auto">
+          <RelationshipsPanel object={object} compact />
         </div>
 
-        {/* Relationships - scrollable */}
-        <div className="border rounded-lg p-4 min-h-[200px] max-h-[500px] overflow-y-auto">
-          <RelationshipsPanel object={object} />
-        </div>
-      </div>
-
-      {/* Row 3: Time Info + Metadata + Form fields */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {/* Time Information */}
+        {/* Time Information - compact */}
         <MetadataDisplay 
           object={object} 
           hideObjectType 
+          compact
           onEditTimeRanges={hasTimeRanges ? () => setEditingTimeRangeIndex(0) : undefined}
         />
 
         {/* Object Form - compact mode */}
-        <div className="border rounded-lg p-4 lg:col-span-2">
+        <div className="border rounded-lg p-3">
           <ObjectForm
             object={formObject}
             onUpdate={async (updates) => {
@@ -561,8 +503,63 @@ const ObjectDetailPage = () => {
             hideSummary
             hideIconName
             hideDetails
+            compact
           />
         </div>
+      </div>
+
+      {/* Row 3: Details - full width */}
+      <div className="border rounded-lg p-4 bg-muted/30 min-h-[150px] max-h-[300px] flex flex-col">
+        <div className="flex items-center justify-between mb-3 flex-shrink-0">
+          <h3 className="text-sm font-semibold text-muted-foreground">Details</h3>
+          <div className="flex items-center gap-1">
+            <Button
+              variant={isEditingDetails ? "default" : "ghost"}
+              size="sm"
+              className="h-6 px-2 text-xs"
+              onClick={() => {
+                if (!isEditingDetails) {
+                  setEditingDetailsValue(object.details || "");
+                }
+                setIsEditingDetails(!isEditingDetails);
+              }}
+            >
+              {isEditingDetails ? "Preview" : "Edit"}
+            </Button>
+            {isEditingDetails && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs"
+                onClick={() => {
+                  handleFieldUpdate("details", editingDetailsValue);
+                  setIsEditingDetails(false);
+                }}
+              >
+                <Check className="w-3 h-3 mr-1" />
+                Save
+              </Button>
+            )}
+          </div>
+        </div>
+        {isEditingDetails ? (
+          <Textarea
+            value={editingDetailsValue}
+            onChange={(e) => setEditingDetailsValue(e.target.value)}
+            placeholder="Add details about this object..."
+            className="flex-1 min-h-[100px] resize-none font-mono text-sm"
+          />
+        ) : (
+          <ScrollArea className="flex-1 [&>[data-radix-scroll-area-viewport]]:!overflow-y-scroll">
+            <div className="prose prose-sm max-w-none pr-3">
+              {object.details ? (
+                <Markdown>{object.details}</Markdown>
+              ) : (
+                <p className="text-muted-foreground text-sm">No details available. Click Edit to add.</p>
+              )}
+            </div>
+          </ScrollArea>
+        )}
       </div>
 
       {/* Time Range Edit Dialog triggered from MetadataDisplay */}

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -2,13 +2,15 @@ import { useState, useEffect, useRef } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import type { Object, ObjectFormData } from "@/types/objects";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import { History, Trash2, Pencil, Check, X } from "lucide-react";
+import { History, Trash2, Pencil, Check, X, Tag, Link2 } from "lucide-react";
 import { SmartBackButton } from "@/components/SmartBackButton";
 import {
   useDeleteObject,
   useObject,
   useUpdateObject,
+  getRelationships,
 } from "@/hooks/useObjectQueries";
 import { ObjectForm } from "@/components/ObjectForm";
 import { RelationshipsPanel } from "@/components/RelationshipsPanel";
@@ -111,6 +113,9 @@ const ObjectDetailPage = () => {
   const updateObjectMutation = useUpdateObject();
   const deleteObjectMutation = useDeleteObject();
   
+  // Fetch relationships for this object
+  const { data: relationships = [] } = getRelationships(object?._id);
+  
   // State for time range editing from metadata display
   const [editingTimeRangeIndex, setEditingTimeRangeIndex] = useState<number | null>(null);
 
@@ -211,13 +216,38 @@ const ObjectDetailPage = () => {
         </div>
       </div>
 
-      {/* Title: Icon + Name (editable inline) */}
-      <EditableTitle
-        icon={object.icon}
-        name={object.name || ""}
-        onIconChange={(icon) => handleFieldUpdate("icon", icon)}
-        onNameChange={(name) => handleFieldUpdate("name", name)}
-      />
+      {/* Title row: Icon + Name on left, Tags + Relationships on right */}
+      <div className="flex items-start justify-between gap-4">
+        <EditableTitle
+          icon={object.icon}
+          name={object.name || ""}
+          onIconChange={(icon) => handleFieldUpdate("icon", icon)}
+          onNameChange={(name) => handleFieldUpdate("name", name)}
+        />
+        
+        {/* Tags and Relationships */}
+        <div className="flex flex-col items-end gap-2 flex-shrink-0">
+          {/* Aliases as tags */}
+          {object.aliases && object.aliases.length > 0 && (
+            <div className="flex flex-wrap gap-1 justify-end">
+              <Tag className="w-3.5 h-3.5 text-muted-foreground mr-1" />
+              {object.aliases.map((alias, idx) => (
+                <Badge key={idx} variant="secondary" className="text-xs">
+                  {alias}
+                </Badge>
+              ))}
+            </div>
+          )}
+          
+          {/* Relationships count */}
+          {relationships.length > 0 && (
+            <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+              <Link2 className="w-3.5 h-3.5" />
+              <span>{relationships.length} relationship{relationships.length !== 1 ? 's' : ''}</span>
+            </div>
+          )}
+        </div>
+      </div>
 
       {/* Main content: Summary on left, Player+Transcript on right */}
       {hasTimeRanges && (

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -187,10 +187,16 @@ const ObjectDetailPage = () => {
   // Autosave settings and status
   const { autoSave, setAutoSave, dateFormat } = useSettingsStore();
   const [pendingChanges, setPendingChanges] = useState<Record<string, any>>({});
+  const pendingChangesRef = useRef<Record<string, any>>({}); // Ref to always get latest pending changes
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [, forceUpdate] = useState(0); // For relative time updates
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Keep ref in sync with state
+  useEffect(() => {
+    pendingChangesRef.current = pendingChanges;
+  }, [pendingChanges]);
   
   // Update relative time every minute
   useEffect(() => {
@@ -212,9 +218,9 @@ const ObjectDetailPage = () => {
     // Get current object from cache to ensure we have the latest version
     const currentObject = queryClient.getQueryData<typeof object>(objectKeys.detail(id!));
     if (!currentObject || !id) return;
-    
-    // Snapshot the pending changes at the moment of save
-    const changesToSave = { ...pendingChanges };
+
+    // Use ref to get latest pending changes (avoids stale closure issue)
+    const changesToSave = { ...pendingChangesRef.current };
     if (Object.keys(changesToSave).length === 0) return;
 
     setIsSaving(true);
@@ -250,8 +256,10 @@ const ObjectDetailPage = () => {
     setIsSaving(false);
     if (successCount > 0) {
       setLastSaved(new Date());
+      // Invalidate to ensure UI shows latest version
+      queryClient.invalidateQueries({ queryKey: objectKeys.detail(id) });
     }
-  }, [id, pendingChanges, updateObjectMutation, queryClient]);
+  }, [id, updateObjectMutation, queryClient]);
 
   // Schedule autosave - debounces all changes together
   const scheduleAutoSave = useCallback(() => {

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -211,7 +211,14 @@ const ObjectDetailPage = () => {
         field,
         value,
       }, {
-        onSuccess: () => setLastSaved(new Date()),
+        onSuccess: () => {
+          setLastSaved(new Date());
+          // Clear this field from pending changes after successful save
+          setPendingChanges(prev => {
+            const { [field]: _, ...rest } = prev;
+            return rest;
+          });
+        },
       });
     }, 2000);
   }, [object, id, updateObjectMutation]);
@@ -228,13 +235,14 @@ const ObjectDetailPage = () => {
   const handleFieldUpdate = useCallback((field: string, value: any) => {
     if (!object || !id) return;
 
+    // Always update pendingChanges immediately for instant visual feedback
+    setPendingChanges(prev => ({ ...prev, [field]: value }));
+
     if (autoSave) {
       // Use throttled save with 2 second delay
       throttledSave(field, value);
-    } else {
-      // Accumulate changes when autosave is off
-      setPendingChanges(prev => ({ ...prev, [field]: value }));
     }
+    // When autosave is off, changes stay in pendingChanges until manual save
   }, [object, id, autoSave, throttledSave]);
 
   // Manual save function
@@ -257,9 +265,11 @@ const ObjectDetailPage = () => {
   const hasPendingChanges = Object.keys(pendingChanges).length > 0;
 
   // Convert Object to ObjectFormData for the form
+  // Merge pendingChanges for instant visual feedback (before throttled save completes)
   const formObject: ObjectFormData = object
     ? {
       ...object,
+      ...pendingChanges, // Apply pending changes immediately for instant UI feedback
       relationship: object.relationship
         ? {
           object: object.relationship.object,

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -13,8 +13,8 @@ import {
 import { ObjectForm } from "@/components/ObjectForm";
 import { RelationshipsPanel } from "@/components/RelationshipsPanel";
 import { MetadataDisplay } from "@/components/MetadataDisplay";
-import { ObjectAudioPlayer } from "@/components/ObjectAudioPlayer";
-import { ObjectTranscriptPanel } from "@/components/ObjectTranscriptPanel";
+import { ObjectPlayerTranscript } from "@/components/ObjectPlayerTranscript";
+import { TimeRangeEditDialog } from "@/components/TimeRangeEditDialog";
 import { Markdown } from "@/components/Markdown";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { EmojiPickerButton } from "@/components/ui/emoji-picker";
@@ -110,6 +110,9 @@ const ObjectDetailPage = () => {
   const { data: object, isLoading: loading, error } = useObject(id);
   const updateObjectMutation = useUpdateObject();
   const deleteObjectMutation = useDeleteObject();
+  
+  // State for time range editing from metadata display
+  const [editingTimeRangeIndex, setEditingTimeRangeIndex] = useState<number | null>(null);
 
   const handleFieldUpdate = (field: string, value: any) => {
     if (!object || !id) return;
@@ -220,10 +223,10 @@ const ObjectDetailPage = () => {
       {hasTimeRanges && (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           {/* Left column: Summary */}
-          <div className="border rounded-lg p-4 bg-muted/30">
-            <h3 className="text-sm font-semibold text-muted-foreground mb-3">Summary</h3>
+          <div className="border rounded-lg p-4 bg-muted/30 h-[700px] flex flex-col">
+            <h3 className="text-sm font-semibold text-muted-foreground mb-3 flex-shrink-0">Summary</h3>
             {hasSummary ? (
-              <ScrollArea className="h-[500px]">
+              <ScrollArea className="flex-1 [&>[data-radix-scroll-area-viewport]]:!overflow-y-scroll">
                 <div className="prose prose-sm max-w-none pr-3">
                   <Markdown>{object.summaries[0].text}</Markdown>
                 </div>
@@ -233,11 +236,8 @@ const ObjectDetailPage = () => {
             )}
           </div>
 
-          {/* Right column: Player on top, Transcript below */}
-          <div className="space-y-4">
-            <ObjectAudioPlayer timeRange={object.timeRanges[0]} />
-            <ObjectTranscriptPanel timeRange={object.timeRanges[0]} />
-          </div>
+          {/* Right column: Combined Player + Transcript with independent scrolling */}
+          <ObjectPlayerTranscript timeRange={object.timeRanges[0]} />
         </div>
       )}
 
@@ -260,12 +260,35 @@ const ObjectDetailPage = () => {
 
         {/* Side panel - Metadata & Relationships */}
         <div className="space-y-4">
-          <MetadataDisplay object={object} hideObjectType />
+          <MetadataDisplay 
+            object={object} 
+            hideObjectType 
+            onEditTimeRanges={hasTimeRanges ? () => setEditingTimeRangeIndex(0) : undefined}
+          />
           <div className="border rounded-lg p-4">
             <RelationshipsPanel object={object} />
           </div>
         </div>
       </div>
+
+      {/* Time Range Edit Dialog triggered from MetadataDisplay */}
+      {editingTimeRangeIndex !== null && object.timeRanges && object.timeRanges[editingTimeRangeIndex] && (
+        <TimeRangeEditDialog
+          open={editingTimeRangeIndex !== null}
+          onOpenChange={(open) => !open && setEditingTimeRangeIndex(null)}
+          timeRange={object.timeRanges[editingTimeRangeIndex]}
+          index={editingTimeRangeIndex}
+          onSave={(index, range) => {
+            const newRanges = [...(object.timeRanges || [])];
+            newRanges[index] = range;
+            handleFieldUpdate("timeRanges", newRanges);
+          }}
+          onDelete={(index) => {
+            const newRanges = (object.timeRanges || []).filter((_, i) => i !== index);
+            handleFieldUpdate("timeRanges", newRanges.length > 0 ? newRanges : undefined);
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -182,7 +182,7 @@ const ObjectDetailPage = () => {
   const [editingDetailsValue, setEditingDetailsValue] = useState("");
   
   // Autosave settings and status
-  const { autoSave, setAutoSave } = useSettingsStore();
+  const { autoSave, setAutoSave, dateFormat } = useSettingsStore();
   const [pendingChanges, setPendingChanges] = useState<Record<string, any>>({});
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
   const [, forceUpdate] = useState(0); // For relative time updates
@@ -475,23 +475,15 @@ const ObjectDetailPage = () => {
         </div>
       )}
 
-      {/* Row 2: Relationships + Time Info + Metadata (side by side) */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-        {/* Relationships - compact */}
-        <div className="border rounded-lg p-3 min-h-[180px] max-h-[300px] overflow-y-auto">
+      {/* Row 2: Relationships (left) | Object Type (right, half) */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Relationships */}
+        <div className="border rounded-lg p-4 min-h-[180px] max-h-[300px] overflow-y-auto">
           <RelationshipsPanel object={object} compact />
         </div>
 
-        {/* Time Information - compact */}
-        <MetadataDisplay 
-          object={object} 
-          hideObjectType 
-          compact
-          onEditTimeRanges={hasTimeRanges ? () => setEditingTimeRangeIndex(0) : undefined}
-        />
-
-        {/* Object Form - compact mode */}
-        <div className="border rounded-lg p-3">
+        {/* Object Type - with labels, clickable */}
+        <div className="border rounded-lg p-4">
           <ObjectForm
             object={formObject}
             onUpdate={async (updates) => {
@@ -503,13 +495,36 @@ const ObjectDetailPage = () => {
             hideSummary
             hideIconName
             hideDetails
-            compact
           />
         </div>
       </div>
 
-      {/* Row 3: Details - full width */}
-      <div className="border rounded-lg p-4 bg-muted/30 min-h-[150px] max-h-[300px] flex flex-col">
+      {/* Row 3: Time Information (left) | Metadata (right) */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Time Information */}
+        <MetadataDisplay 
+          object={object} 
+          hideObjectType
+          hideMetadata
+          onEditTimeRanges={hasTimeRanges ? () => setEditingTimeRangeIndex(0) : undefined}
+        />
+
+        {/* Metadata */}
+        <div className="border rounded-lg p-4 space-y-3">
+          <h3 className="text-sm font-semibold text-muted-foreground">Metadata</h3>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+            <div className="text-muted-foreground">Created:</div>
+            <div>{formatTime(object.createdAt, dateFormat)}</div>
+            <div className="text-muted-foreground">Updated:</div>
+            <div>{formatTime(object.updatedAt, dateFormat)}</div>
+            <div className="text-muted-foreground">Version:</div>
+            <div>{object.version}</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Row 4: Details - full width */}
+      <div className="border rounded-lg p-4 bg-muted/30 min-h-[120px] max-h-[250px] flex flex-col">
         <div className="flex items-center justify-between mb-3 flex-shrink-0">
           <h3 className="text-sm font-semibold text-muted-foreground">Details</h3>
           <div className="flex items-center gap-1">
@@ -547,7 +562,7 @@ const ObjectDetailPage = () => {
             value={editingDetailsValue}
             onChange={(e) => setEditingDetailsValue(e.target.value)}
             placeholder="Add details about this object..."
-            className="flex-1 min-h-[100px] resize-none font-mono text-sm"
+            className="flex-1 min-h-[80px] resize-none font-mono text-sm"
           />
         ) : (
           <ScrollArea className="flex-1 [&>[data-radix-scroll-area-viewport]]:!overflow-y-scroll">

--- a/frontend/src/pages/settings/GeneralSettingsPage.tsx
+++ b/frontend/src/pages/settings/GeneralSettingsPage.tsx
@@ -70,6 +70,9 @@ const GeneralSettingsPage = () => {
               className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             >
               <optgroup label="Gregorian (Local)">
+                <option value="gregorian-local-natural">
+                  Natural ({formatTime(now, "gregorian-local-natural")})
+                </option>
                 <option value="gregorian-local-iso">
                   ISO 8601 ({formatTime(now, "gregorian-local-iso")})
                 </option>

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -29,6 +29,7 @@ interface SettingsState {
   autoGainControl: boolean;
   playbackRate: number;
   volume: number;
+  autoSave: boolean;
   setApiEndpoint: (endpoint: string) => void;
   setClientId: (id: string) => void;
   setClientSecret: (secret: string) => void;
@@ -41,6 +42,7 @@ interface SettingsState {
   setAutoGainControl: (enabled: boolean) => void;
   setPlaybackRate: (rate: number) => void;
   setVolume: (volume: number) => void;
+  setAutoSave: (enabled: boolean) => void;
   clearSettings: () => void;
 }
 
@@ -69,6 +71,7 @@ export const useSettingsStore = create<SettingsState>()(
       autoGainControl: false,
       playbackRate: DEFAULT_PLAYBACK_RATE,
       volume: DEFAULT_VOLUME,
+      autoSave: true,
       setApiEndpoint: (endpoint) => set({ apiEndpoint: endpoint }),
       setClientId: (id) => set({ clientId: id }),
       setClientSecret: (secret) => set({ clientSecret: secret }),
@@ -83,6 +86,7 @@ export const useSettingsStore = create<SettingsState>()(
       setAutoGainControl: (enabled) => set({ autoGainControl: enabled }),
       setPlaybackRate: (rate) => set({ playbackRate: rate }),
       setVolume: (volume) => set({ volume }),
+      setAutoSave: (enabled) => set({ autoSave: enabled }),
       clearSettings: () =>
         set({
           apiEndpoint: DEFAULT_API_ENDPOINT,
@@ -97,6 +101,7 @@ export const useSettingsStore = create<SettingsState>()(
           autoGainControl: false,
           playbackRate: DEFAULT_PLAYBACK_RATE,
           volume: DEFAULT_VOLUME,
+          autoSave: true,
         }),
     }),
     {

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -4,6 +4,7 @@ import { persist } from "zustand/middleware";
 type Theme = "light" | "dark" | "system";
 
 type TimeFormat =
+  | "gregorian-local-natural"
   | "gregorian-local-iso"
   | "gregorian-local-verbose"
   | "gregorian-local-european"
@@ -48,7 +49,7 @@ function getDefaultApiEndpoint(): string {
 }
 
 const DEFAULT_API_ENDPOINT = getDefaultApiEndpoint();
-const DEFAULT_TIME_FORMAT: TimeFormat = "gregorian-local-iso";
+const DEFAULT_TIME_FORMAT: TimeFormat = "gregorian-local-natural";
 const DEFAULT_TRANSCRIPT_THRESHOLD_HOURS = 12;
 const DEFAULT_PLAYBACK_RATE = 1;
 const DEFAULT_VOLUME = 1;


### PR DESCRIPTION
## Summary
- Add "View in Timeline" button to audio player for quick navigation to timeline view
- Fix transcript auto-scroll to only scroll within container, not the whole page
- Fix autosave stale closure bug that prevented changes from being saved
- Reduce autosave delay from 2s to 500ms for faster feedback
- Use full object type names (Person, Event, Conversation, Relationship, Promise) instead of abbreviations
- Stop audio playback when reaching end of time range
- Fix Timeline button URL parameters to work correctly with TimelinePage
- Update version number in History button after saves

## Test plan
- [x] Open an object detail page with transcript
- [x] Click audio player progress bar - verify only transcript scrolls, not whole page
- [x] Click "View in Timeline" button - verify it navigates to correct time range
- [x] Toggle object type buttons (Person, Event, etc.) - verify they save and show full names
- [x] Edit multiple fields quickly - verify autosave works without 409 conflicts
- [x] Play audio to end - verify it stops automatically