### PR TITLE
Optimize ObjectsPage data fetching with cached counts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ misc/.htpasswd
 /misc/nginx/ssl/*.pem
 /misc/secrets/
 cloudflare.ini
+qdrant_storage/*

--- a/backend/app/lib/objects/resource.server.ts
+++ b/backend/app/lib/objects/resource.server.ts
@@ -191,6 +191,15 @@ const getTimeRangeSchema = z.object({
   ),
 });
 
+const getCountsSchema = z.object({
+  action: z.literal("getCounts").describe(
+    "Get cached counts per object type. Returns cached values for fast loading."
+  ),
+  forceRefresh: z.boolean().optional().describe(
+    "If true, recalculate counts from database and update cache"
+  ),
+});
+
 const objectsRequestSchema = z.discriminatedUnion("action", [
   createObjectSchema,
   updateObjectSchema,
@@ -201,6 +210,7 @@ const objectsRequestSchema = z.discriminatedUnion("action", [
   getHistorySchema,
   exploreTimeRangeSchema,
   getTimeRangeSchema,
+  getCountsSchema,
 ]);
 
 export type ObjectsRequest = z.infer<typeof objectsRequestSchema>;
@@ -230,6 +240,179 @@ export class ObjectsResource
 
   async getRootDB() {
     return getRootDB();
+  }
+
+  // Calculate and cache object counts in the database
+  private async refreshCounts(): Promise<{
+    person: number;
+    event: number;
+    relationship: number;
+    promise: number;
+    conversation: number;
+    other: number;
+    orphaned: number;
+    total: number;
+    updatedAt: Date;
+  }> {
+    const db = await this.getRootDB();
+    const objectsCollection = db.collection("objects");
+
+    // Calculate type counts with a single aggregation
+    const countsPipeline = [
+      {
+        $group: {
+          _id: null,
+          person: { $sum: { $cond: [{ $eq: ["$isPerson", true] }, 1, 0] } },
+          event: { $sum: { $cond: [{ $eq: ["$isEvent", true] }, 1, 0] } },
+          promise: { $sum: { $cond: [{ $eq: ["$isPromise", true] }, 1, 0] } },
+          relationship: {
+            $sum: {
+              $cond: [
+                {
+                  $and: [
+                    { $eq: ["$isRelationship", true] },
+                    { $ne: ["$isPromise", true] },
+                  ],
+                },
+                1,
+                0,
+              ],
+            },
+          },
+          conversation: { $sum: { $cond: [{ $eq: ["$isConversation", true] }, 1, 0] } },
+          other: {
+            $sum: {
+              $cond: [
+                {
+                  $and: [
+                    { $ne: ["$isPerson", true] },
+                    { $ne: ["$isEvent", true] },
+                    { $ne: ["$isRelationship", true] },
+                    { $ne: ["$isPromise", true] },
+                    { $ne: ["$isConversation", true] },
+                  ],
+                },
+                1,
+                0,
+              ],
+            },
+          },
+          total: { $sum: 1 },
+        },
+      },
+    ];
+
+    const countsResult = await objectsCollection.aggregate(countsPipeline).toArray();
+    const typeCounts = countsResult[0] || {
+      person: 0,
+      event: 0,
+      relationship: 0,
+      promise: 0,
+      conversation: 0,
+      other: 0,
+      total: 0,
+    };
+
+    // Calculate orphaned count (objects not referenced in any relationship)
+    const orphanedPipeline = [
+      {
+        $match: {
+          isRelationship: { $ne: true },
+        },
+      },
+      {
+        $lookup: {
+          from: "objects",
+          let: { objectId: "$_id" },
+          pipeline: [
+            {
+              $match: {
+                isRelationship: true,
+                $expr: {
+                  $or: [
+                    { $eq: ["$relationship.subject", "$$objectId"] },
+                    { $eq: ["$relationship.object", "$$objectId"] },
+                  ],
+                },
+              },
+            },
+            { $limit: 1 },
+          ],
+          as: "references",
+        },
+      },
+      {
+        $match: {
+          references: { $size: 0 },
+        },
+      },
+      { $count: "total" },
+    ];
+
+    const orphanedResult = await objectsCollection.aggregate(orphanedPipeline).toArray();
+    const orphanedCount = orphanedResult[0]?.total ?? 0;
+
+    const stats = {
+      person: typeCounts.person,
+      event: typeCounts.event,
+      relationship: typeCounts.relationship,
+      promise: typeCounts.promise,
+      conversation: typeCounts.conversation,
+      other: typeCounts.other,
+      orphaned: orphanedCount,
+      total: typeCounts.total,
+      updatedAt: new Date(),
+    };
+
+    // Store in cache collection
+    await db.collection("object_stats").updateOne(
+      { _id: "counts" },
+      { $set: stats },
+      { upsert: true }
+    );
+
+    return stats;
+  }
+
+  // Get cached counts, or calculate if not exists
+  private async getCachedCounts(): Promise<{
+    person: number;
+    event: number;
+    relationship: number;
+    promise: number;
+    conversation: number;
+    other: number;
+    orphaned: number;
+    total: number;
+    updatedAt: Date | null;
+    stale?: boolean;
+  } | null> {
+    const db = await this.getRootDB();
+    const cached = await db.collection("object_stats").findOne({ _id: "counts" });
+    if (!cached) return null;
+    return {
+      person: cached.person,
+      event: cached.event,
+      relationship: cached.relationship,
+      promise: cached.promise,
+      conversation: cached.conversation,
+      other: cached.other,
+      orphaned: cached.orphaned,
+      total: cached.total,
+      updatedAt: cached.updatedAt,
+      stale: cached.stale,
+    };
+  }
+
+  // Invalidate counts cache (called after create/update/delete)
+  private async invalidateCountsCache(): Promise<void> {
+    // Just mark as stale by updating a flag, don't recalculate immediately
+    const db = await this.getRootDB();
+    await db.collection("object_stats").updateOne(
+      { _id: "counts" },
+      { $set: { stale: true } },
+      { upsert: true }
+    );
   }
 
   private async recordHistory(
@@ -285,6 +468,9 @@ export class ObjectsResource
           undefined,
           doc,
         );
+
+        // Invalidate counts cache
+        await this.invalidateCountsCache();
 
         return { insertedId: result.insertedId };
       }
@@ -376,6 +562,12 @@ export class ObjectsResource
           input.value,
         );
 
+        // Invalidate counts cache if type-related fields changed
+        const typeFields = ["isPerson", "isEvent", "isRelationship", "isPromise", "isConversation"];
+        if (typeFields.includes(input.field) || input.field.startsWith("relationship")) {
+          await this.invalidateCountsCache();
+        }
+
         return result;
       }
 
@@ -406,6 +598,9 @@ export class ObjectsResource
           current,
           undefined,
         );
+
+        // Invalidate counts cache
+        await this.invalidateCountsCache();
 
         return { deletedCount: result.deletedCount };
       }
@@ -879,6 +1074,21 @@ export class ObjectsResource
         return { start: null, end: null };
       }
 
+      case "getCounts": {
+        // Get cached counts or calculate if not available
+        if (input.forceRefresh) {
+          return await this.refreshCounts();
+        }
+
+        const cached = await this.getCachedCounts();
+        if (cached && !cached.stale) {
+          return cached;
+        }
+
+        // Cache doesn't exist or is stale, recalculate
+        return await this.refreshCounts();
+      }
+
       default:
         throw new Error("Unknown action");
     }
@@ -895,6 +1105,7 @@ export class ObjectsResource
       getHistory: ["read"],
       exploreTimeRange: ["read"],
       getTimeRange: ["read"],
+      getCounts: ["read"],
     };
 
     return [

--- a/frontend/src/pages/ObjectsPage.tsx
+++ b/frontend/src/pages/ObjectsPage.tsx
@@ -504,12 +504,11 @@ const ObjectsPage = () => {
 
     // Only do expensive orphaned checks when the filter is active
     if (showOrphanedOnly) {
-      // First, exclude relationship objects themselves (they're not "orphaned")
-      pipeline.push({
-        $match: {
-          isRelationship: { $ne: true },
-        },
-      });
+      // Relationships cannot be orphaned - they ARE the references between objects
+      // Skip fetching for relationship type when orphaned filter is active
+      if (type === "relationship") {
+        return [];
+      }
       
       // Check if this object is referenced as subject in any relationship
       pipeline.push({

--- a/frontend/src/pages/ObjectsPage.tsx
+++ b/frontend/src/pages/ObjectsPage.tsx
@@ -374,7 +374,7 @@ type ObjectWithRelations = ObjectModel & {
   referencesFromCount?: number;
 };
 
-const ITEMS_PER_TYPE = 25; // Initial items per type
+const ITEMS_PER_TYPE = 20; // Initial items per type
 const LOAD_MORE_COUNT = 50; // Items to load when clicking "load more"
 const MAX_ITEMS_PER_TYPE = 500; // Maximum items per type for "load all"
 
@@ -435,7 +435,6 @@ const ObjectsPage = () => {
   });
   const [countsLoading, setCountsLoading] = useState(true);
   const [orphanedCount, setOrphanedCount] = useState<number | null>(null);
-  const [orphanedCountLoading, setOrphanedCountLoading] = useState(false);
 
   const q = searchParams.get("q") || "";
   const sortBy = (searchParams.get("sort") as SortOption) || "updatedAt";
@@ -547,7 +546,6 @@ const ObjectsPage = () => {
         },
       });
       // Filter for orphaned objects (not referenced anywhere)
-      // An object is orphaned if it has no references as subject AND no references as object
       pipeline.push({
         $match: {
           $expr: {
@@ -558,9 +556,16 @@ const ObjectsPage = () => {
           },
         },
       });
+      // Sort and limit AFTER orphaned filtering (can't optimize this case)
+      pipeline.push(getSortStage());
+      pipeline.push({ $limit: limit });
     } else {
-      // Only add relationship lookups when not filtering for orphaned (they're expensive)
-      // These are needed to display relationship information in the UI
+      // OPTIMIZATION: Sort and limit BEFORE expensive lookups
+      // This way we only do lookups on the limited set of documents
+      pipeline.push(getSortStage());
+      pipeline.push({ $limit: limit });
+      
+      // Now add relationship lookups only on the limited documents
       if (type === "relationship") {
         pipeline.push({
           $lookup: {
@@ -590,65 +595,10 @@ const ObjectsPage = () => {
             preserveNullAndEmptyArrays: true,
           },
         });
-      } else {
-        // Add reference counts for non-relationship types
-        // Count references TO this object (where it's the target)
-        pipeline.push({
-          $lookup: {
-            from: "objects",
-            let: { objectId: "$_id" },
-            pipeline: [
-              {
-                $match: {
-                  isRelationship: true,
-                  $expr: { $eq: ["$relationship.object", "$$objectId"] },
-                },
-              },
-              { $count: "count" },
-            ],
-            as: "referencesToArr",
-          },
-        });
-        // Count references FROM this object (where it's the source)
-        pipeline.push({
-          $lookup: {
-            from: "objects",
-            let: { objectId: "$_id" },
-            pipeline: [
-              {
-                $match: {
-                  isRelationship: true,
-                  $expr: { $eq: ["$relationship.subject", "$$objectId"] },
-                },
-              },
-              { $count: "count" },
-            ],
-            as: "referencesFromArr",
-          },
-        });
-        // Extract counts from arrays
-        pipeline.push({
-          $addFields: {
-            referencesToCount: {
-              $ifNull: [{ $arrayElemAt: ["$referencesToArr.count", 0] }, 0],
-            },
-            referencesFromCount: {
-              $ifNull: [{ $arrayElemAt: ["$referencesFromArr.count", 0] }, 0],
-            },
-          },
-        });
-        // Clean up temporary arrays
-        pipeline.push({
-          $project: {
-            referencesToArr: 0,
-            referencesFromArr: 0,
-          },
-        });
       }
+      // Skip reference counts for initial load - they're not critical
+      // and cause significant slowdown
     }
-
-    pipeline.push(getSortStage());
-    pipeline.push({ $limit: limit });
 
     return await callResource("mongo", {
       action: "aggregate",
@@ -657,76 +607,25 @@ const ObjectsPage = () => {
     });
   }, [q, getSortStage, getTypeMatch, showOrphanedOnly]);
 
-  // Fetch total counts per type
-  const fetchCounts = useCallback(async () => {
+  // Fetch total counts per type from cached API (no search filter - absolute counts)
+  const fetchCounts = useCallback(async (forceRefresh = false) => {
     setCountsLoading(true);
     try {
-      const searchMatch: Record<string, unknown> = {};
-      if (q.trim()) {
-        searchMatch.$text = { $search: q.trim() };
-      }
-
-      const pipeline = [
-        { $match: searchMatch },
-        {
-          $group: {
-            _id: null,
-            person: { $sum: { $cond: [{ $eq: ["$isPerson", true] }, 1, 0] } },
-            event: { $sum: { $cond: [{ $eq: ["$isEvent", true] }, 1, 0] } },
-            promise: { $sum: { $cond: [{ $eq: ["$isPromise", true] }, 1, 0] } },
-            relationship: {
-              $sum: {
-                $cond: [
-                  {
-                    $and: [
-                      { $eq: ["$isRelationship", true] },
-                      { $ne: ["$isPromise", true] },
-                    ],
-                  },
-                  1,
-                  0,
-                ],
-              },
-            },
-            conversation: { $sum: { $cond: [{ $eq: ["$isConversation", true] }, 1, 0] } },
-            other: {
-              $sum: {
-                $cond: [
-                  {
-                    $and: [
-                      { $ne: ["$isPerson", true] },
-                      { $ne: ["$isEvent", true] },
-                      { $ne: ["$isRelationship", true] },
-                      { $ne: ["$isPromise", true] },
-                      { $ne: ["$isConversation", true] },
-                    ],
-                  },
-                  1,
-                  0,
-                ],
-              },
-            },
-            total: { $sum: 1 },
-          },
-        },
-      ];
-
-      const result = await callResource("mongo", {
-        action: "aggregate",
-        collection: "objects",
-        pipeline,
+      const result = await callResource("objects", {
+        action: "getCounts",
+        forceRefresh,
       });
 
-      if (result && result.length > 0) {
-        const counts = result[0];
+      if (result) {
         setTotalCounts({
-          person: counts.person || 0,
-          event: counts.event || 0,
-          relationship: counts.relationship || 0,
-          promise: counts.promise || 0,
-          conversation: counts.conversation || 0,
-          other: counts.other || 0,
+          person: result.person || 0,
+          event: result.event || 0,
+          relationship: result.relationship || 0,
+          promise: result.promise || 0,
+          conversation: result.conversation || 0,
+          other: result.other || 0,
         });
+        setOrphanedCount(result.orphaned ?? 0);
       } else {
         setTotalCounts({
           person: 0,
@@ -736,104 +635,18 @@ const ObjectsPage = () => {
           conversation: 0,
           other: 0,
         });
+        setOrphanedCount(0);
       }
     } catch (err) {
       console.error("Failed to fetch counts:", err);
     } finally {
       setCountsLoading(false);
     }
-  }, [q]);
+  }, []);
 
   useEffect(() => {
     fetchCounts();
   }, [fetchCounts]);
-
-  // Fetch orphaned objects count
-  const fetchOrphanedCount = useCallback(async () => {
-    setOrphanedCountLoading(true);
-    try {
-      const searchMatch: Record<string, unknown> = {
-        isRelationship: { $ne: true },
-      };
-      
-      if (q.trim()) {
-        searchMatch.$text = { $search: q.trim() };
-      }
-
-      const pipeline = [
-        { $match: searchMatch },
-        // Check if this object is referenced as subject in any relationship
-        {
-          $lookup: {
-            from: "objects",
-            let: { objectId: "$_id" },
-            pipeline: [
-              {
-                $match: {
-                  isRelationship: true,
-                  $expr: { $eq: ["$relationship.subject", "$$objectId"] },
-                },
-              },
-              { $limit: 1 },
-            ],
-            as: "referencedAsSubject",
-          },
-        },
-        // Check if this object is referenced as object in any relationship
-        {
-          $lookup: {
-            from: "objects",
-            let: { objectId: "$_id" },
-            pipeline: [
-              {
-                $match: {
-                  isRelationship: true,
-                  $expr: { $eq: ["$relationship.object", "$$objectId"] },
-                },
-              },
-              { $limit: 1 },
-            ],
-            as: "referencedAsObject",
-          },
-        },
-        // Filter for orphaned objects (not referenced anywhere)
-        {
-          $match: {
-            $expr: {
-              $and: [
-                { $eq: [{ $size: { $ifNull: ["$referencedAsSubject", []] } }, 0] },
-                { $eq: [{ $size: { $ifNull: ["$referencedAsObject", []] } }, 0] },
-              ],
-            },
-          },
-        },
-        { $count: "total" },
-      ];
-
-      const result = await callResource("mongo", {
-        action: "aggregate",
-        collection: "objects",
-        pipeline,
-      });
-
-      // $count returns [] if no matches, or [{ total: number }] if matches found
-      if (result && Array.isArray(result) && result.length > 0 && typeof result[0] === 'object' && 'total' in result[0]) {
-        setOrphanedCount(result[0].total as number);
-      } else {
-        // If no results (empty array), count is 0
-        setOrphanedCount(0);
-      }
-    } catch (err) {
-      console.error("Failed to fetch orphaned count:", err);
-      setOrphanedCount(0); // Set to 0 on error
-    } finally {
-      setOrphanedCountLoading(false);
-    }
-  }, [q]);
-
-  useEffect(() => {
-    fetchOrphanedCount();
-  }, [fetchOrphanedCount]);
 
   // Track if we should refetch on focus (only after initial load)
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
@@ -949,11 +762,10 @@ const ObjectsPage = () => {
     if (lastLocationKeyRef.current !== null && lastLocationKeyRef.current !== location.key) {
       refetchCurrentData();
       fetchCounts();
-      fetchOrphanedCount();
     }
     
     lastLocationKeyRef.current = location.key;
-  }, [location.key, hasLoadedOnce, refetchCurrentData, fetchCounts, fetchOrphanedCount]);
+  }, [location.key, hasLoadedOnce, refetchCurrentData, fetchCounts]);
 
   // Also refetch when browser tab regains visibility
   useEffect(() => {
@@ -963,7 +775,6 @@ const ObjectsPage = () => {
       if (document.visibilityState === 'visible') {
         refetchCurrentData();
         fetchCounts();
-        fetchOrphanedCount();
       }
     };
 
@@ -972,7 +783,7 @@ const ObjectsPage = () => {
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [hasLoadedOnce, refetchCurrentData, fetchCounts, fetchOrphanedCount]);
+  }, [hasLoadedOnce, refetchCurrentData, fetchCounts]);
 
   // Load more for a specific type
   const loadMore = useCallback(async (type: ObjectType, loadAll = false) => {
@@ -1157,27 +968,21 @@ const ObjectsPage = () => {
               Show Orphaned
             </>
           )}
-          {orphanedCountLoading ? (
-            <Badge variant="secondary" className="text-xs ml-1">
-              ...
-            </Badge>
-          ) : (
-            <Badge variant="secondary" className="text-xs ml-1">
-              {orphanedCount ?? 0}
-            </Badge>
-          )}
+          <Badge variant="secondary" className="text-xs ml-1">
+            {countsLoading ? "..." : (orphanedCount ?? 0)}
+          </Badge>
         </Button>
         
         {/* Refresh counts button */}
         <Button
           variant="ghost"
           size="sm"
-          onClick={() => fetchOrphanedCount()}
-          disabled={orphanedCountLoading}
+          onClick={() => fetchCounts(true)}
+          disabled={countsLoading}
           className="flex items-center gap-1"
-          title="Refresh orphaned count"
+          title="Refresh counts"
         >
-          <RefreshCw className={`w-4 h-4 ${orphanedCountLoading ? 'animate-spin' : ''}`} />
+          <RefreshCw className={`w-4 h-4 ${countsLoading ? 'animate-spin' : ''}`} />
         </Button>
 
         <div className="flex items-center gap-2 ml-auto">


### PR DESCRIPTION
## Summary
- Add `getCounts` action to ObjectsResource for cached object counts retrieval with invalidation on create/update/delete
- Refactor ObjectsPage to use cached counts API, reducing initial load times
- Optimize aggregation pipelines by sorting/limiting before expensive lookups
- Skip relationship types when orphaned filter is active (relationships can't be orphaned)

## Test plan
- [x] Verify ObjectsPage loads faster with cached counts
- [x] Confirm counts refresh correctly after creating/updating/deleting objects
- [x] Test orphaned filter works correctly (excludes relationship type)
- [x] Verify refresh button recalculates counts from database
