### PR TITLE
Add macOS local Whisper transcription server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,6 +193,14 @@ NODE_ENV=development
 # JOB_INTERVAL_SECONDS=
 
 # Transcription Configuration
+# Dedicated transcription provider override.
+# These only affect speech-to-text requests and let you keep a separate LLM provider.
+# Example on macOS when running the local Whisper server from python/whisper_server:
+#   - Backend in Docker: TRANSCRIPTION_BASE_URL=http://host.docker.internal:9000
+#   - Backend native:    TRANSCRIPTION_BASE_URL=http://localhost:9000
+# TRANSCRIPTION_BASE_URL=
+# TRANSCRIPTION_API_KEY=
+#
 # Language code for transcription (default: "auto")
 # Set this to prevent faster-whisper language detection failures with short audio
 # TRANSCRIPTION_LANGUAGE=auto

--- a/README.md
+++ b/README.md
@@ -157,15 +157,17 @@ You can reconfigure these settings anytime in Settings.
 
 ### Run Whisper Locally on Mac
 
-If you want local transcription on macOS without the GPU stack, start the bundled Whisper server:
+If you want local transcription on macOS without the GPU stack, build and run the bundled Whisper server container:
 
 ```bash
-cd python/whisper_server
-uv sync
+docker build -t mycelia-whisper-local -f python/whisper_server/Dockerfile .
 
-WHISPER_MODEL=small \
-WHISPER_API_KEY=mycelia-local \
-uv run mycelia-whisper-server
+docker container run --rm \
+  -p 9000:9000 \
+  -e WHISPER_MODEL=small \
+  -e WHISPER_API_KEY=mycelia-local \
+  -v mycelia-whisper-models:/models \
+  mycelia-whisper-local
 ```
 
 The server exposes:
@@ -182,7 +184,7 @@ TRANSCRIPTION_BASE_URL=http://host.docker.internal:9000
 TRANSCRIPTION_API_KEY=mycelia-local
 ```
 
-If you run the backend natively instead of in Docker, use `http://localhost:9000` as the base URL. The first transcription request downloads the configured `faster-whisper` model.
+If you run the backend natively instead of in Docker, use `http://localhost:9000` as the base URL. The first transcription request downloads the configured `faster-whisper` model into the mounted Docker volume.
 
 #### Managing API Keys
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ your own words.
 - Continuous import from Apple Voice Memos, Google Drive, and local folders.
 - Automated pipeline: VAD → Transcription → Conversation extraction → Summarization.
 - Smart chunking, waveform normalization, and diarization-friendly segments.
-- Whisper transcription via local GPU or any remote OpenAI-compatible server.
+- Whisper transcription via local GPU, a Mac-local server, or any remote OpenAI-compatible server.
 - Audio recording, playback (0.5x–3x speed, volume up to 300%), and WAV export.
 - Pipeline monitoring UI with real-time session tracking and error handling.
 
@@ -154,6 +154,35 @@ When you first open the frontend, you'll be guided through a setup wizard:
    - Any OpenAI-compatible API endpoint
 
 You can reconfigure these settings anytime in Settings.
+
+### Run Whisper Locally on Mac
+
+If you want local transcription on macOS without the GPU stack, start the bundled Whisper server:
+
+```bash
+cd python/whisper_server
+uv sync
+
+WHISPER_MODEL=small \
+WHISPER_API_KEY=mycelia-local \
+uv run mycelia-whisper-server
+```
+
+The server exposes:
+
+- `GET /health`
+- `GET /v1/models`
+- `POST /v1/audio/transcriptions`
+
+To make Mycelia use it for transcription only, add these to `.env` before starting the backend:
+
+```bash
+# Backend running in Docker on macOS
+TRANSCRIPTION_BASE_URL=http://host.docker.internal:9000
+TRANSCRIPTION_API_KEY=mycelia-local
+```
+
+If you run the backend natively instead of in Docker, use `http://localhost:9000` as the base URL. The first transcription request downloads the configured `faster-whisper` model.
 
 #### Managing API Keys
 

--- a/backend/app/lib/transcription/resource.server.ts
+++ b/backend/app/lib/transcription/resource.server.ts
@@ -17,7 +17,8 @@ const transcriptionRequestSchema = z.object({
 type TranscriptionRequest = z.infer<typeof transcriptionRequestSchema>;
 type TranscriptionResponse = any | Response;
 
-export class TranscriptionResource implements Resource<TranscriptionRequest, TranscriptionResponse> {
+export class TranscriptionResource
+  implements Resource<TranscriptionRequest, TranscriptionResponse> {
   code = "transcription";
   description = "Audio transcription";
   schemas: {
@@ -28,19 +29,51 @@ export class TranscriptionResource implements Resource<TranscriptionRequest, Tra
     response: z.any() as z.ZodType<TranscriptionResponse>,
   };
 
-  async getInferenceProvider(): Promise<{ baseUrl: string; apiKey: string } | null> {
-    const config = await getServerConfig();
-    const inference = config.inference;
-    if (!inference?.baseUrl || !inference?.apiKey) {
-      return null;
+  async getInferenceProvider(): Promise<
+    { baseUrl: string; apiKey: string } | null
+  > {
+    const dedicatedBaseUrl = Deno.env.get("TRANSCRIPTION_BASE_URL");
+    const dedicatedApiKey = Deno.env.get("TRANSCRIPTION_API_KEY");
+    if (dedicatedBaseUrl && dedicatedApiKey) {
+      return {
+        baseUrl: dedicatedBaseUrl,
+        apiKey: dedicatedApiKey,
+      };
     }
-    return {
-      baseUrl: inference.baseUrl,
-      apiKey: inference.apiKey,
-    };
+
+    const envBaseUrl = Deno.env.get("OPENAI_BASE_URL");
+    const envApiKey = Deno.env.get("OPENAI_API_KEY");
+    if (envBaseUrl && envApiKey) {
+      return {
+        baseUrl: envBaseUrl,
+        apiKey: envApiKey,
+      };
+    }
+
+    const config = await getServerConfig();
+    const transcription = config.transcription;
+    if (transcription?.baseUrl && transcription?.apiKey) {
+      return {
+        baseUrl: transcription.baseUrl,
+        apiKey: transcription.apiKey,
+      };
+    }
+
+    const inference = config.inference;
+    if (inference?.baseUrl && inference?.apiKey) {
+      return {
+        baseUrl: inference.baseUrl,
+        apiKey: inference.apiKey,
+      };
+    }
+
+    return null;
   }
 
-  async use(input: TranscriptionRequest, auth: Auth): Promise<TranscriptionResponse> {
+  async use(
+    input: TranscriptionRequest,
+    auth: Auth,
+  ): Promise<TranscriptionResponse> {
     const startTime = performance.now();
     const span = tracer.startSpan("transcription_resource_use", {
       attributes: {
@@ -55,37 +88,55 @@ export class TranscriptionResource implements Resource<TranscriptionRequest, Tra
           if (!provider) {
             span.setStatus({
               code: 2,
-              message: "Inference provider not configured",
+              message: "Transcription provider not configured",
             });
             throw new Error(
-              "Inference provider not configured. Please configure it in server settings."
+              "Transcription provider not configured. Configure TRANSCRIPTION_BASE_URL / TRANSCRIPTION_API_KEY, or set a transcription or inference provider in server settings.",
             );
           }
 
+          let baseUrl = provider.baseUrl.replace(/\/$/, "");
+          if (baseUrl.endsWith("/v1")) {
+            baseUrl = baseUrl.slice(0, -3);
+          }
+
           span.setAttributes({
+            "transcription.base_url": baseUrl,
             "transcription.has_api_key": !!provider.apiKey,
           });
 
           let fileBuffer: Uint8Array;
           if (input.file instanceof Uint8Array) {
             fileBuffer = input.file;
-          } else if (input.file instanceof Buffer ) {
+          } else if (input.file instanceof Buffer) {
             fileBuffer = new Uint8Array(input.file);
           } else if (input.file?.buffer instanceof Uint8Array) {
             fileBuffer = new Uint8Array(input.file.buffer);
-          } else if (input.file && typeof input.file === "object" && "$binary" in input.file) {
-            const binary = (input.file as { $binary: { base64: string; subType?: string } }).$binary;
+          } else if (
+            input.file && typeof input.file === "object" &&
+            "$binary" in input.file
+          ) {
+            const binary =
+              (input.file as { $binary: { base64: string; subType?: string } })
+                .$binary;
             const decoded = Buffer.from(binary.base64, "base64");
             fileBuffer = new Uint8Array(decoded);
           } else {
-            throw new Error(`Invalid file format. Expected Uint8Array, Buffer, or EJSON binary. Got ${typeof input.file}, ${Object.keys(input.file)}`);
+            throw new Error(
+              `Invalid file format. Expected Uint8Array, Buffer, or EJSON binary. Got ${typeof input
+                .file}, ${Object.keys(input.file)}`,
+            );
           }
 
           const formData = new FormData();
           const newBuffer = new Uint8Array(fileBuffer);
-          const blob = new Blob([newBuffer], { type: input.fileType || "audio/mpeg" });
+          const blob = new Blob([newBuffer], {
+            type: input.fileType || "audio/mpeg",
+          });
           const fileName = input.fileName || "audio.mp3";
-          const file = new File([blob], fileName, { type: input.fileType || "audio/mpeg" });
+          const file = new File([blob], fileName, {
+            type: input.fileType || "audio/mpeg",
+          });
           formData.append("file", file);
           if (input.language) {
             formData.append("language", input.language);
@@ -96,7 +147,7 @@ export class TranscriptionResource implements Resource<TranscriptionRequest, Tra
           formData.append("model", "whisper");
 
           const proxyResponse = await fetch(
-            provider.baseUrl.replace(/\/$/, "") + "/v1/audio/transcriptions",
+            `${baseUrl}/v1/audio/transcriptions`,
             {
               method: "POST",
               headers: {
@@ -166,4 +217,3 @@ export async function getTranscriptionResource(
 ): Promise<(input: TranscriptionRequest) => Promise<TranscriptionResponse>> {
   return auth.getResource("transcription");
 }
-

--- a/backend/app/lib/transcription/resource.test.ts
+++ b/backend/app/lib/transcription/resource.test.ts
@@ -1,0 +1,131 @@
+import { expect } from "@std/expect";
+import { withFixtures } from "@/tests/fixtures.server.ts";
+import { getServerAuth } from "@/lib/auth/core.server.ts";
+import { getConfigResource as getConfigResourceFn } from "@/lib/config/resource.server.ts";
+import { TranscriptionResource } from "./resource.server.ts";
+
+function withEnv(
+  name: string,
+  value: string | undefined,
+): () => void {
+  const previous = Deno.env.get(name);
+  if (value === undefined) {
+    Deno.env.delete(name);
+  } else {
+    Deno.env.set(name, value);
+  }
+
+  return () => {
+    if (previous === undefined) {
+      Deno.env.delete(name);
+    } else {
+      Deno.env.set(name, previous);
+    }
+  };
+}
+
+Deno.test(
+  "transcription provider prefers dedicated transcription config",
+  withFixtures(["Mongo"], async () => {
+    const restoreDedicatedBaseUrl = withEnv(
+      "TRANSCRIPTION_BASE_URL",
+      undefined,
+    );
+    const restoreDedicatedApiKey = withEnv("TRANSCRIPTION_API_KEY", undefined);
+    const restoreOpenAiBaseUrl = withEnv("OPENAI_BASE_URL", undefined);
+    const restoreOpenAiApiKey = withEnv("OPENAI_API_KEY", undefined);
+    const resource = new TranscriptionResource();
+    try {
+      const configResource = await getConfigResourceFn(await getServerAuth());
+      await configResource({
+        action: "patch",
+        path: "inference",
+        updates: {
+          baseUrl: "https://shared.example",
+          apiKey: "shared-key",
+        },
+      });
+      await configResource({
+        action: "patch",
+        path: "transcription",
+        updates: {
+          baseUrl: "https://transcription.example",
+          apiKey: "transcription-key",
+        },
+      });
+
+      const provider = await resource.getInferenceProvider();
+
+      expect(provider).toEqual({
+        baseUrl: "https://transcription.example",
+        apiKey: "transcription-key",
+      });
+    } finally {
+      restoreOpenAiApiKey();
+      restoreOpenAiBaseUrl();
+      restoreDedicatedApiKey();
+      restoreDedicatedBaseUrl();
+    }
+  }),
+);
+
+Deno.test(
+  "transcription provider falls back to shared inference config",
+  withFixtures(["Mongo"], async () => {
+    const restoreDedicatedBaseUrl = withEnv(
+      "TRANSCRIPTION_BASE_URL",
+      undefined,
+    );
+    const restoreDedicatedApiKey = withEnv("TRANSCRIPTION_API_KEY", undefined);
+    const restoreOpenAiBaseUrl = withEnv("OPENAI_BASE_URL", undefined);
+    const restoreOpenAiApiKey = withEnv("OPENAI_API_KEY", undefined);
+    const resource = new TranscriptionResource();
+    try {
+      const configResource = await getConfigResourceFn(await getServerAuth());
+      await configResource({
+        action: "patch",
+        path: "inference",
+        updates: {
+          baseUrl: "https://shared.example",
+          apiKey: "shared-key",
+        },
+      });
+
+      const provider = await resource.getInferenceProvider();
+
+      expect(provider).toEqual({
+        baseUrl: "https://shared.example",
+        apiKey: "shared-key",
+      });
+    } finally {
+      restoreOpenAiApiKey();
+      restoreOpenAiBaseUrl();
+      restoreDedicatedApiKey();
+      restoreDedicatedBaseUrl();
+    }
+  }),
+);
+
+Deno.test(
+  "transcription env vars override config",
+  withFixtures(["Mongo"], async () => {
+    const restoreBaseUrl = withEnv(
+      "TRANSCRIPTION_BASE_URL",
+      "http://localhost:9000",
+    );
+    const restoreApiKey = withEnv("TRANSCRIPTION_API_KEY", "local-whisper");
+
+    try {
+      const resource = new TranscriptionResource();
+      const provider = await resource.getInferenceProvider();
+
+      expect(provider).toEqual({
+        baseUrl: "http://localhost:9000",
+        apiKey: "local-whisper",
+      });
+    } finally {
+      restoreApiKey();
+      restoreBaseUrl();
+    }
+  }),
+);

--- a/python/README.md
+++ b/python/README.md
@@ -225,15 +225,17 @@ Speech-to-text transcription services.
 
 ### Local Whisper Server (`whisper_server/`)
 
-Run a local OpenAI-compatible transcription server on macOS:
+Run a local OpenAI-compatible transcription server on macOS with Docker:
 
 ```bash
-cd python/whisper_server
-uv sync
+docker build -t mycelia-whisper-local -f python/whisper_server/Dockerfile .
 
-WHISPER_MODEL=small \
-WHISPER_API_KEY=mycelia-local \
-uv run mycelia-whisper-server
+docker container run --rm \
+  -p 9000:9000 \
+  -e WHISPER_MODEL=small \
+  -e WHISPER_API_KEY=mycelia-local \
+  -v mycelia-whisper-models:/models \
+  mycelia-whisper-local
 ```
 
 Then point Mycelia transcription traffic at it:
@@ -242,7 +244,7 @@ Then point Mycelia transcription traffic at it:
 - Backend running natively: `TRANSCRIPTION_BASE_URL=http://localhost:9000`
 - Shared secret: `TRANSCRIPTION_API_KEY=mycelia-local`
 
-See [whisper_server/README.md](./whisper_server/README.md) for the available environment variables.
+See [whisper_server/README.md](./whisper_server/README.md) for the available environment variables and the native non-Docker fallback.
 
 ## Configuration
 

--- a/python/README.md
+++ b/python/README.md
@@ -223,6 +223,27 @@ Options:
 ### Transcription (`stt.py`)
 Speech-to-text transcription services.
 
+### Local Whisper Server (`whisper_server/`)
+
+Run a local OpenAI-compatible transcription server on macOS:
+
+```bash
+cd python/whisper_server
+uv sync
+
+WHISPER_MODEL=small \
+WHISPER_API_KEY=mycelia-local \
+uv run mycelia-whisper-server
+```
+
+Then point Mycelia transcription traffic at it:
+
+- Backend in Docker: `TRANSCRIPTION_BASE_URL=http://host.docker.internal:9000`
+- Backend running natively: `TRANSCRIPTION_BASE_URL=http://localhost:9000`
+- Shared secret: `TRANSCRIPTION_API_KEY=mycelia-local`
+
+See [whisper_server/README.md](./whisper_server/README.md) for the available environment variables.
+
 ## Configuration
 
 Configuration is managed through `settings.py`.

--- a/python/whisper_server/Dockerfile
+++ b/python/whisper_server/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    WHISPER_HOST=0.0.0.0 \
+    WHISPER_PORT=9000 \
+    WHISPER_CACHE_DIR=/models
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir uv
+
+COPY python/whisper_server /app
+
+RUN uv pip install --system .
+
+EXPOSE 9000
+VOLUME ["/models"]
+
+CMD ["mycelia-whisper-server"]

--- a/python/whisper_server/README.md
+++ b/python/whisper_server/README.md
@@ -1,0 +1,37 @@
+# Mycelia Whisper Server
+
+Lightweight OpenAI-compatible transcription server for local development on macOS.
+
+## Features
+
+- `POST /v1/audio/transcriptions` for direct Mycelia integration
+- `GET /v1/models` so the Settings "Test API" action works
+- `POST /asr` compatibility endpoint for the existing Whisper proxy flow
+- Optional bearer auth via `WHISPER_API_KEY`
+
+## Run Locally
+
+```bash
+cd python/whisper_server
+uv sync
+
+WHISPER_MODEL=small \
+WHISPER_API_KEY=mycelia-local \
+uv run mycelia-whisper-server
+```
+
+The server listens on `http://localhost:9000` by default.
+
+## Configuration
+
+- `WHISPER_HOST` default: `0.0.0.0`
+- `WHISPER_PORT` default: `9000`
+- `WHISPER_MODEL` default: `small`
+- `WHISPER_DEVICE` default: `cpu`
+- `WHISPER_COMPUTE_TYPE` default: `int8`
+- `WHISPER_API_KEY` optional bearer token
+- `WHISPER_CACHE_DIR` optional model cache directory
+- `WHISPER_VAD_FILTER` default: `true`
+- `WHISPER_BEAM_SIZE` default: `5`
+
+The first request downloads the configured `faster-whisper` model if it is not already cached.

--- a/python/whisper_server/README.md
+++ b/python/whisper_server/README.md
@@ -9,7 +9,22 @@ Lightweight OpenAI-compatible transcription server for local development on macO
 - `POST /asr` compatibility endpoint for the existing Whisper proxy flow
 - Optional bearer auth via `WHISPER_API_KEY`
 
-## Run Locally
+## Run With Docker
+
+```bash
+docker build -t mycelia-whisper-local -f python/whisper_server/Dockerfile .
+
+docker container run --rm \
+  -p 9000:9000 \
+  -e WHISPER_MODEL=small \
+  -e WHISPER_API_KEY=mycelia-local \
+  -v mycelia-whisper-models:/models \
+  mycelia-whisper-local
+```
+
+The server listens on `http://localhost:9000` by default.
+
+## Run Natively
 
 ```bash
 cd python/whisper_server
@@ -19,8 +34,6 @@ WHISPER_MODEL=small \
 WHISPER_API_KEY=mycelia-local \
 uv run mycelia-whisper-server
 ```
-
-The server listens on `http://localhost:9000` by default.
 
 ## Configuration
 

--- a/python/whisper_server/pyproject.toml
+++ b/python/whisper_server/pyproject.toml
@@ -1,13 +1,15 @@
 [project]
 name = "mycelia-whisper"
 version = "0.1.0"
-description = ""
+description = "OpenAI-compatible local Whisper server for Mycelia"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.115.12",
-    "requests>=2.31.0",
-    "ffmpeg-python>=0.2.0",
+    "faster-whisper>=1.1.1",
     "python-multipart>=0.0.20",
-    "uvicorn>=0.34.2",
+    "uvicorn[standard]>=0.34.2",
 ]
+
+[project.scripts]
+mycelia-whisper-server = "server:main"

--- a/python/whisper_server/requirements.txt
+++ b/python/whisper_server/requirements.txt
@@ -1,5 +1,4 @@
-fastapi==0.104.1
-requests>=2.31.0
-ffmpeg-python==0.2.0
-uvicorn[standard]==0.24.0
-python-multipart
+fastapi>=0.115.12
+faster-whisper>=1.1.1
+python-multipart>=0.0.20
+uvicorn[standard]>=0.34.2

--- a/python/whisper_server/server.py
+++ b/python/whisper_server/server.py
@@ -1,0 +1,239 @@
+import logging
+import os
+import tempfile
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+from fastapi import Depends, FastAPI, File, Form, HTTPException, Query, UploadFile
+from fastapi.responses import JSONResponse, PlainTextResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from faster_whisper import WhisperModel
+
+
+logging.basicConfig(
+    level=os.getenv("WHISPER_LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger("mycelia.whisper")
+
+APP_NAME = "Mycelia Whisper Server"
+API_KEY = os.getenv("WHISPER_API_KEY")
+MODEL_NAME = os.getenv("WHISPER_MODEL", "small")
+DEVICE = os.getenv("WHISPER_DEVICE", "cpu")
+COMPUTE_TYPE = os.getenv("WHISPER_COMPUTE_TYPE", "int8")
+CACHE_DIR = os.getenv("WHISPER_CACHE_DIR")
+BEAM_SIZE = int(os.getenv("WHISPER_BEAM_SIZE", "5"))
+
+
+def parse_bool(value: str | None, default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+VAD_FILTER = parse_bool(os.getenv("WHISPER_VAD_FILTER"), True)
+security = HTTPBearer(auto_error=False)
+
+app = FastAPI(
+    title=APP_NAME,
+    version="0.1.0",
+    description="OpenAI-compatible transcription server backed by faster-whisper.",
+)
+
+
+@lru_cache(maxsize=1)
+def get_model() -> WhisperModel:
+    kwargs = {
+        "device": DEVICE,
+        "compute_type": COMPUTE_TYPE,
+    }
+    if CACHE_DIR:
+        kwargs["download_root"] = CACHE_DIR
+
+    logger.info(
+        "Loading faster-whisper model",
+        extra={
+            "model": MODEL_NAME,
+            "device": DEVICE,
+            "compute_type": COMPUTE_TYPE,
+            "cache_dir": CACHE_DIR,
+        },
+    )
+    return WhisperModel(MODEL_NAME, **kwargs)
+
+
+async def verify_api_key(
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> None:
+    if not API_KEY:
+        return
+
+    if not credentials or credentials.credentials != API_KEY:
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid API key",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+async def save_upload(upload: UploadFile) -> str:
+    suffix = Path(upload.filename or "audio").suffix or ".wav"
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_file:
+        while chunk := await upload.read(1024 * 1024):
+            temp_file.write(chunk)
+        return temp_file.name
+
+
+def build_transcript_response(
+    *,
+    audio_path: str,
+    task: str,
+    language: Optional[str],
+    prompt: Optional[str],
+) -> dict:
+    transcribe_language = None if not language or language == "auto" else language
+    segments, info = get_model().transcribe(
+        audio_path,
+        task=task,
+        language=transcribe_language,
+        initial_prompt=prompt,
+        vad_filter=VAD_FILTER,
+        beam_size=BEAM_SIZE,
+    )
+
+    payload_segments = []
+    text_parts: list[str] = []
+
+    for index, segment in enumerate(segments):
+        text = segment.text.strip()
+        if text:
+            text_parts.append(text)
+
+        payload_segments.append({
+            "id": index,
+            "start": float(segment.start),
+            "end": float(segment.end),
+            "text": text,
+            "avg_logprob": getattr(segment, "avg_logprob", None),
+            "no_speech_prob": getattr(segment, "no_speech_prob", None),
+        })
+
+    duration = float(getattr(info, "duration", 0.0) or 0.0)
+    if duration == 0.0 and payload_segments:
+        duration = payload_segments[-1]["end"]
+
+    return {
+        "task": task,
+        "language": getattr(info, "language", None) or transcribe_language or "unknown",
+        "duration": duration,
+        "text": " ".join(text_parts).strip(),
+        "segments": payload_segments,
+    }
+
+
+async def transcribe_upload(
+    *,
+    upload: UploadFile,
+    task: str,
+    language: Optional[str],
+    prompt: Optional[str],
+) -> dict:
+    audio_path = await save_upload(upload)
+    try:
+        return build_transcript_response(
+            audio_path=audio_path,
+            task=task,
+            language=language,
+            prompt=prompt,
+        )
+    finally:
+        try:
+            os.unlink(audio_path)
+        except FileNotFoundError:
+            pass
+
+
+@app.get("/health")
+async def health() -> dict:
+    return {
+        "status": "ok",
+        "model": MODEL_NAME,
+        "device": DEVICE,
+        "compute_type": COMPUTE_TYPE,
+    }
+
+
+@app.get("/v1/models")
+async def list_models(_: None = Depends(verify_api_key)) -> dict:
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": MODEL_NAME,
+                "object": "model",
+                "created": 0,
+                "owned_by": "mycelia-whisper",
+            }
+        ],
+    }
+
+
+@app.post("/v1/audio/transcriptions")
+async def transcribe_audio(
+    file: UploadFile = File(...),
+    model: str = Form("whisper"),
+    language: Optional[str] = Form(None),
+    prompt: Optional[str] = Form(None),
+    response_format: str = Form("json"),
+    _: None = Depends(verify_api_key),
+):
+    del model
+
+    result = await transcribe_upload(
+        upload=file,
+        task="transcribe",
+        language=language,
+        prompt=prompt,
+    )
+
+    if response_format == "text":
+        return PlainTextResponse(result["text"])
+
+    return JSONResponse(result)
+
+
+@app.post("/asr")
+async def asr(
+    audio_file: UploadFile = File(...),
+    task: str = Query("transcribe"),
+    output: str = Query("json"),
+    language: Optional[str] = Query(None),
+    initial_prompt: Optional[str] = Query(None),
+    _: None = Depends(verify_api_key),
+):
+    result = await transcribe_upload(
+        upload=audio_file,
+        task=task,
+        language=language,
+        prompt=initial_prompt,
+    )
+
+    if output == "txt":
+        return PlainTextResponse(result["text"])
+
+    return JSONResponse(result)
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run(
+        app,
+        host=os.getenv("WHISPER_HOST", "0.0.0.0"),
+        port=int(os.getenv("WHISPER_PORT", "9000")),
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a standalone faster-whisper server for local transcription and a dedicated transcription-provider path in the backend
- add a Dockerfile and document a macOS flow based on docker build + docker container run
- document the new transcription env overrides in the root README, python README, and .env.example

## Testing
- deno test -A app/lib/transcription/resource.test.ts app/lib/config/resource.test.ts
- python3 -m py_compile python/whisper_server/server.py