### PR TITLE
Add read-only portable memory export

### DIFF
--- a/backend/app/lib/memory-export/resource.server.test.ts
+++ b/backend/app/lib/memory-export/resource.server.test.ts
@@ -1,0 +1,156 @@
+import { expect } from "@std/expect";
+
+import { Auth } from "@/lib/auth/core.server.ts";
+import { ResourceManager } from "@/lib/auth/resources.ts";
+import { memoryExportQuery, MemoryExportResource } from "./resource.server.ts";
+
+class FakeCursor {
+  closed = false;
+  index = 0;
+
+  constructor(readonly documents: Record<string, unknown>[]) {}
+
+  hasNext(): Promise<boolean> {
+    return Promise.resolve(this.index < this.documents.length);
+  }
+
+  next(): Promise<Record<string, unknown> | null> {
+    return Promise.resolve(this.documents[this.index++] ?? null);
+  }
+
+  close(): Promise<void> {
+    this.closed = true;
+    return Promise.resolve();
+  }
+}
+
+class TestMemoryExportResource extends MemoryExportResource {
+  readonly cursor = new FakeCursor([
+    { _id: "1", text: "first" },
+    { _id: "2", text: "second" },
+    { _id: "3", text: "third" },
+  ]);
+  findArgs: unknown[] = [];
+
+  protected override getDatabase(): Promise<any> {
+    return Promise.resolve({
+      collection: (name: string) => ({
+        countDocuments: (query: unknown) => {
+          this.findArgs = [name, query];
+          return Promise.resolve(3);
+        },
+        find: (query: unknown, options: unknown) => {
+          this.findArgs = [name, query, options];
+          return this.cursor;
+        },
+      }),
+    });
+  }
+}
+
+const auth = new Auth({
+  principal: "exporter",
+  policies: [{ resource: "memory-export/*", action: "read", effect: "allow" }],
+});
+
+async function expectForbidden(operation: Promise<unknown>): Promise<void> {
+  try {
+    await operation;
+    throw new Error("Expected operation to be forbidden");
+  } catch (error) {
+    expect(error).toBeInstanceOf(Response);
+    expect((error as Response).status).toBe(403);
+  }
+}
+
+Deno.test("memory export accepts only fixed collections, read actions, and bounded pages", () => {
+  const resource = new MemoryExportResource();
+  expect(
+    resource.schemas.request.safeParse({
+      action: "count",
+      collection: "objects",
+    }).success,
+  ).toBe(true);
+  expect(
+    resource.schemas.request.safeParse({
+      action: "count",
+      collection: "audio_chunks",
+    }).success,
+  ).toBe(false);
+  expect(
+    resource.schemas.request.safeParse({
+      action: "find",
+      collection: "objects",
+    }).success,
+  ).toBe(false);
+  expect(
+    resource.schemas.request.safeParse({
+      action: "getFirstBatch",
+      collection: "objects",
+      batchSize: 1001,
+    }).success,
+  ).toBe(false);
+  expect(resource.extractActions({ action: "count", collection: "objects" }))
+    .toEqual([
+      { path: ["memory-export", "objects"], actions: ["read"] },
+    ]);
+});
+
+Deno.test("memory export excludes system and tool message roles server-side", () => {
+  expect(memoryExportQuery("messages")).toEqual({
+    role: { $nin: ["system", "tool", "developer", "function"] },
+    "raw.role": { $nin: ["system", "tool", "developer", "function"] },
+  });
+  expect(memoryExportQuery("chats")).toEqual({});
+});
+
+Deno.test("memory export requires its dedicated read policy", async () => {
+  const manager = new ResourceManager();
+  manager.registerResource(new MemoryExportResource());
+  const wrongAuth = new Auth({
+    principal: "mongo-reader",
+    policies: [{ resource: "db/objects", action: "read", effect: "allow" }],
+  });
+
+  await expectForbidden(
+    manager.getResource("memory-export", wrongAuth)({
+      action: "count",
+      collection: "objects",
+    }),
+  );
+});
+
+Deno.test("memory export paginates with a principal-bound cursor", async () => {
+  const resource = new TestMemoryExportResource();
+  const first = await resource.use({
+    action: "getFirstBatch",
+    collection: "messages",
+    batchSize: 2,
+  }, auth) as any;
+
+  expect(first.data.map((item: any) => item._id)).toEqual(["1", "2"]);
+  expect(first.hasMore).toBe(true);
+  expect(first.cursorId).not.toBe("");
+  expect(resource.findArgs[0]).toBe("messages");
+  expect(resource.findArgs[1]).toEqual(memoryExportQuery("messages"));
+
+  await expectForbidden(
+    resource.use({
+      action: "getMore",
+      collection: "messages",
+      cursorId: first.cursorId,
+      batchSize: 1,
+    }, new Auth({ principal: "other" })),
+  );
+
+  const second = await resource.use({
+    action: "getMore",
+    collection: "messages",
+    cursorId: first.cursorId,
+    batchSize: 1,
+  }, auth) as any;
+  expect(second.data.map((item: any) => item._id)).toEqual(["3"]);
+  expect(second.hasMore).toBe(false);
+  expect(second.cursorId).toBe("");
+  expect(resource.cursor.closed).toBe(true);
+});

--- a/backend/app/lib/memory-export/resource.server.ts
+++ b/backend/app/lib/memory-export/resource.server.ts
@@ -1,0 +1,232 @@
+import { z } from "zod";
+import type { Db } from "mongodb";
+
+import type { Auth } from "@/lib/auth/core.server.ts";
+import type { Resource } from "@/lib/auth/resources.ts";
+import { getRootDB } from "@/lib/mongo/core.server.ts";
+import { permissionDenied } from "@/lib/auth/utils.ts";
+
+export const MEMORY_EXPORT_COLLECTIONS = [
+  "objects",
+  "transcriptions",
+  "messages",
+  "chats",
+] as const;
+
+const collectionSchema = z.enum(MEMORY_EXPORT_COLLECTIONS);
+const batchSizeSchema = z.number().int().min(1).max(1000).default(250);
+
+const countSchema = z.object({
+  action: z.literal("count"),
+  collection: collectionSchema,
+});
+
+const firstBatchSchema = z.object({
+  action: z.literal("getFirstBatch"),
+  collection: collectionSchema,
+  batchSize: batchSizeSchema,
+});
+
+const moreSchema = z.object({
+  action: z.literal("getMore"),
+  collection: collectionSchema,
+  cursorId: z.string().min(1),
+  batchSize: batchSizeSchema,
+});
+
+const requestSchema = z.discriminatedUnion("action", [
+  countSchema,
+  firstBatchSchema,
+  moreSchema,
+]);
+
+const responseSchema = z.union([
+  z.object({ count: z.number().int().nonnegative() }),
+  z.object({
+    cursorId: z.string(),
+    data: z.array(z.record(z.string(), z.any())),
+    hasMore: z.boolean(),
+  }),
+]);
+
+export type MemoryExportRequest = z.infer<typeof requestSchema>;
+export type MemoryExportResponse = z.infer<typeof responseSchema>;
+
+type ExportCollection = typeof MEMORY_EXPORT_COLLECTIONS[number];
+
+interface CursorEntry {
+  collection: ExportCollection;
+  cursor: any;
+  expiresAt: number;
+  principal: string;
+}
+
+const CURSOR_TTL_MS = 30 * 60 * 1000;
+const EXCLUDED_MESSAGE_ROLES = ["system", "tool", "developer", "function"];
+
+const PROJECTIONS: Record<ExportCollection, Record<string, 1>> = {
+  objects: {
+    _id: 1,
+    name: 1,
+    details: 1,
+    summaries: 1,
+    aliases: 1,
+    location: 1,
+    timeRanges: 1,
+    relationship: 1,
+    isPerson: 1,
+    isEvent: 1,
+    isRelationship: 1,
+    isPromise: 1,
+    isConversation: 1,
+    isTag: 1,
+    starred: 1,
+    createdAt: 1,
+    updatedAt: 1,
+  },
+  transcriptions: {
+    _id: 1,
+    text: 1,
+    segments: 1,
+    start: 1,
+    end: 1,
+    duration: 1,
+    speaker: 1,
+    speaker_name: 1,
+    source_file_id: 1,
+    original_id: 1,
+    language: 1,
+    createdAt: 1,
+    updatedAt: 1,
+  },
+  messages: {
+    _id: 1,
+    text: 1,
+    content: 1,
+    role: 1,
+    "raw.role": 1,
+    "raw.content": 1,
+    senderName: 1,
+    "sender.name": 1,
+    user: 1,
+    author: 1,
+    platform: 1,
+    chatId: 1,
+    timestamp: 1,
+    date: 1,
+    createdAt: 1,
+    updatedAt: 1,
+  },
+  chats: {
+    _id: 1,
+    summary: 1,
+    title: 1,
+    name: 1,
+    platform: 1,
+    timestamp: 1,
+    createdAt: 1,
+    updatedAt: 1,
+  },
+};
+
+export function memoryExportQuery(
+  collection: ExportCollection,
+): Record<string, unknown> {
+  if (collection !== "messages") return {};
+  return {
+    role: { $nin: EXCLUDED_MESSAGE_ROLES },
+    "raw.role": { $nin: EXCLUDED_MESSAGE_ROLES },
+  };
+}
+
+export class MemoryExportResource
+  implements Resource<MemoryExportRequest, MemoryExportResponse> {
+  code = "memory-export";
+  description =
+    "Read-only, cursor-paginated export of portable personal memory";
+  schemas = { request: requestSchema, response: responseSchema };
+
+  private readonly cursors = new Map<string, CursorEntry>();
+
+  protected getDatabase(): Promise<Db> {
+    return getRootDB();
+  }
+
+  private async cleanupExpiredCursors(): Promise<void> {
+    const now = Date.now();
+    for (const [cursorId, entry] of this.cursors) {
+      if (entry.expiresAt >= now) continue;
+      this.cursors.delete(cursorId);
+      await entry.cursor.close().catch(() => {});
+    }
+  }
+
+  private async readBatch(cursor: any, batchSize: number): Promise<any[]> {
+    const data: any[] = [];
+    while (data.length < batchSize && await cursor.hasNext()) {
+      const document = await cursor.next();
+      if (document) data.push(document);
+    }
+    return data;
+  }
+
+  async use(
+    input: MemoryExportRequest,
+    auth: Auth,
+  ): Promise<MemoryExportResponse> {
+    await this.cleanupExpiredCursors();
+
+    if (input.action === "getMore") {
+      const entry = this.cursors.get(input.cursorId);
+      if (
+        !entry || entry.principal !== auth.principal ||
+        entry.collection !== input.collection
+      ) {
+        permissionDenied(
+          "Export cursor is missing or does not belong to this principal",
+        );
+      }
+      const data = await this.readBatch(entry.cursor, input.batchSize);
+      const hasMore = await entry.cursor.hasNext();
+      if (hasMore) {
+        entry.expiresAt = Date.now() + CURSOR_TTL_MS;
+      } else {
+        this.cursors.delete(input.cursorId);
+        await entry.cursor.close();
+      }
+      return { cursorId: hasMore ? input.cursorId : "", data, hasMore };
+    }
+
+    const db = await this.getDatabase();
+    const collection = db.collection(input.collection);
+    const query = memoryExportQuery(input.collection);
+    if (input.action === "count") {
+      return { count: await collection.countDocuments(query) };
+    }
+
+    const cursor = collection.find(query, {
+      projection: PROJECTIONS[input.collection],
+      sort: { _id: 1 },
+      batchSize: input.batchSize,
+    });
+    const data = await this.readBatch(cursor, input.batchSize);
+    const hasMore = await cursor.hasNext();
+    if (!hasMore) {
+      await cursor.close();
+      return { cursorId: "", data, hasMore: false };
+    }
+
+    const cursorId = crypto.randomUUID();
+    this.cursors.set(cursorId, {
+      collection: input.collection,
+      cursor,
+      expiresAt: Date.now() + CURSOR_TTL_MS,
+      principal: auth.principal,
+    });
+    return { cursorId, data, hasMore: true };
+  }
+
+  extractActions(input: MemoryExportRequest) {
+    return [{ path: ["memory-export", input.collection], actions: ["read"] }];
+  }
+}

--- a/backend/app/lib/resources/registry.ts
+++ b/backend/app/lib/resources/registry.ts
@@ -13,6 +13,7 @@ import { MessengerResource } from "@/lib/messenger/resource.server.ts";
 import { SearchResource } from "@/lib/search/resource.server.ts";
 import { DocsResource } from "@/lib/docs/resource.server.ts";
 import { ConfigResource } from "@/lib/config/resource.server.ts";
+import { MemoryExportResource } from "@/lib/memory-export/resource.server.ts";
 
 const resources = [
   MongoResource,
@@ -28,6 +29,7 @@ const resources = [
   SearchResource,
   DocsResource,
   ConfigResource,
+  MemoryExportResource,
 ];
 
 export async function setupResources(): Promise<void> {

--- a/docs/MEMORY_EXPORT_API.md
+++ b/docs/MEMORY_EXPORT_API.md
@@ -1,0 +1,59 @@
+# Portable memory export API
+
+Mycelia exposes a dedicated, read-only resource for product integrations that
+need portable user memory without general database access. It is available at
+`POST /api/resource/memory-export` and uses the same bearer-token authentication
+as other resources.
+
+The contract exposes only `objects`, `transcriptions`, `messages`, and `chats`.
+It does not expose audio or GridFS, Redis, credentials, jobs, prompts,
+configuration, access logs, or any write operation. System, tool, developer,
+and function messages are filtered by the server. Responses use fixed field
+projections so new internal fields do not become exportable by accident.
+
+## Authorization
+
+Create a dedicated API key with only these policies:
+
+```json
+[
+  { "resource": "memory-export/objects", "action": "read", "effect": "allow" },
+  { "resource": "memory-export/transcriptions", "action": "read", "effect": "allow" },
+  { "resource": "memory-export/messages", "action": "read", "effect": "allow" },
+  { "resource": "memory-export/chats", "action": "read", "effect": "allow" }
+]
+```
+
+Do not grant the integration `db/**`, `mongo`, filesystem, Redis, jobs, config,
+or wildcard policies. Keep the token in the integration process environment and
+send it only over TLS (or to the local development endpoint).
+
+## Cursor pagination
+
+Count an allowed collection:
+
+```json
+{ "action": "count", "collection": "objects" }
+```
+
+Start an `_id`-ordered export (page size must be 1 through 1000):
+
+```json
+{ "action": "getFirstBatch", "collection": "objects", "batchSize": 250 }
+```
+
+If `hasMore` is true, continue with the returned cursor and the same collection:
+
+```json
+{
+  "action": "getMore",
+  "collection": "objects",
+  "cursorId": "returned-opaque-id",
+  "batchSize": 250
+}
+```
+
+Cursors expire after 30 minutes and are bound to the principal and collection
+that created them. Consumers must finish one cursor before starting a fresh
+snapshot of that collection. An empty `cursorId` with `hasMore: false` marks the
+last page.


### PR DESCRIPTION
## What changed

- add a dedicated authenticated `memory-export` resource
- allow only cursor-paginated reads from `objects`, `transcriptions`, `messages`, and `chats`
- apply fixed field projections and server-side system/tool-family message filtering
- bind cursors to the authenticated principal and collection
- document least-privilege API-key policies and operator usage

## Why

The Mycelia → Synthius bridge previously depended on the generic Mongo resource. Product adoption needs a narrow, maintainable, read-only export boundary that cannot reach audio/GridFS, Redis, credentials, jobs, prompts, configuration, or write operations.

## Impact

Integrations can use `POST /api/resource/memory-export` with dedicated `memory-export/*` read policies. Existing resources and schemas are unchanged.

## Validation

- `deno fmt --check app/lib/memory-export/resource.server.ts app/lib/memory-export/resource.server.test.ts app/lib/resources/registry.ts`
- `deno lint app/lib/memory-export/resource.server.ts app/lib/memory-export/resource.server.test.ts app/lib/resources/registry.ts`
- `deno check app/lib/memory-export/resource.server.ts app/lib/memory-export/resource.server.test.ts app/lib/resources/registry.ts`
- `deno test --allow-env --allow-read app/lib/memory-export/resource.server.test.ts` — 4 passed