### PR TITLE
Validate requested STT model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -206,8 +206,9 @@ NODE_ENV=development
 # Generate the same value for the GPU stack with: openssl rand -hex 32
 # PROXY_API_KEY=
 
-# STT_MODEL - Fallback model provenance when a remote STT server does not return
-# X-Whisper-Model. The Mycelia Portainer proxy returns this header automatically.
+# STT_MODEL - Model required by python/stt.py and fallback provenance when a
+# remote STT server does not return X-Whisper-Model. The Mycelia Portainer proxy
+# validates this against its loaded ASR_MODEL and returns the header automatically.
 # STT_MODEL=large-v3-turbo
 
 # Model Configuration

--- a/gpu/PORTAINER.md
+++ b/gpu/PORTAINER.md
@@ -104,6 +104,14 @@ uv run stt.py --limit 1
 
 The proxy returns its configured model in `X-Whisper-Model`. Transcriptions created by `python/stt.py` store this provenance in MongoDB at `transcriptions.metadata.model`, with the provider recorded at `transcriptions.metadata.provider`. Set `STT_MODEL` in Mycelia only as a fallback when using another OpenAI-compatible server that does not return the header.
 
+Require a specific model when starting the worker:
+
+```bash
+docker compose exec python-worker python stt.py --model large-v3
+```
+
+The worker prints both the requested model and the model reported by the server. The Portainer service loads one model per deployment, so `--model` verifies that the requested model is loaded; it does not hot-swap models. A mismatch stops transcription with an error instead of saving misleading provenance. Change `ASR_MODEL` in Portainer and redeploy before requesting a different model.
+
 ## Same-host Docker networking
 
 When Mycelia and STT run on the same Docker host, either keep using the host's Tailscale address or attach both stacks to a shared external Docker network. Do not use a container name from an unrelated Compose network: Docker DNS only resolves names on shared networks.

--- a/gpu/proxy/server.py
+++ b/gpu/proxy/server.py
@@ -73,6 +73,7 @@ async def verify_api_key(credentials: HTTPAuthorizationCredentials = Depends(sec
 async def transcribe_audio(
     request: Request,
     file: UploadFile = File(...),
+    model: Optional[str] = Form(None),
     language: Optional[str] = Form(None),
     prompt: Optional[str] = Form(None),
     _: bool = Depends(verify_api_key)
@@ -81,6 +82,16 @@ async def transcribe_audio(
     OpenAI-compatible transcription endpoint that forwards to whisper service
     """
     logger.info(f"Received transcription request for file: {file.filename}")
+
+    if model and model != "whisper" and model != ASR_MODEL:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Requested model '{model}' is not loaded; "
+                f"this server is configured for '{ASR_MODEL}'. "
+                "Change ASR_MODEL and redeploy the STT stack."
+            ),
+        )
     
     try:
         # Read the audio file

--- a/python/stt.py
+++ b/python/stt.py
@@ -51,6 +51,8 @@ logger = logging.getLogger(__name__)
 
 TRANSCRIPTION_SERVER_URL: str | None = None
 TRANSCRIPTION_API_KEY: str | None = None
+TRANSCRIPTION_MODEL = "whisper"
+REPORTED_TRANSCRIPTION_MODELS: set[str] = set()
 
 
 NO_SPEECH_DETECTED = object()
@@ -61,8 +63,12 @@ def initialize_backend_auth():
     job_token_var.set(jwt_token)
 
 
-def configure_transcription_endpoint(server: str | None, api_key: str | None):
-    global TRANSCRIPTION_SERVER_URL, TRANSCRIPTION_API_KEY
+def configure_transcription_endpoint(
+    server: str | None,
+    api_key: str | None,
+    model: str = "whisper",
+):
+    global TRANSCRIPTION_SERVER_URL, TRANSCRIPTION_API_KEY, TRANSCRIPTION_MODEL
 
     if not server:
         TRANSCRIPTION_SERVER_URL = None
@@ -77,7 +83,9 @@ def configure_transcription_endpoint(server: str | None, api_key: str | None):
 
     TRANSCRIPTION_SERVER_URL = server.rstrip("/")
     TRANSCRIPTION_API_KEY = resolved_api_key
+    TRANSCRIPTION_MODEL = model
     tqdm.write(f"Using remote transcription server: {TRANSCRIPTION_SERVER_URL}")
+    tqdm.write(f"Requested transcription model: {TRANSCRIPTION_MODEL}")
 
 
 def transcribe_with_remote_server(
@@ -96,7 +104,7 @@ def transcribe_with_remote_server(
         files={
             "file": (file_name, audio_bytes, file_type),
         },
-        data={"model": "whisper"},
+        data={"model": TRANSCRIPTION_MODEL},
         timeout=300,
     )
 
@@ -121,6 +129,20 @@ def transcribe_with_remote_server(
         or transcript.get("model")
         or "unknown"
     )
+    if (
+        TRANSCRIPTION_MODEL != "whisper"
+        and model_used != "unknown"
+        and model_used != TRANSCRIPTION_MODEL
+    ):
+        raise RuntimeError(
+            "Remote STT model mismatch: "
+            f"requested {TRANSCRIPTION_MODEL}, server used {model_used}"
+        )
+
+    if model_used not in REPORTED_TRANSCRIPTION_MODELS:
+        tqdm.write(f"Transcription model used: {model_used}")
+        REPORTED_TRANSCRIPTION_MODELS.add(model_used)
+
     metadata = transcript.get("metadata")
     if not isinstance(metadata, dict):
         metadata = {}
@@ -659,6 +681,14 @@ if __name__ == '__main__':
         help='API key for the STT server. Defaults to PROXY_API_KEY if set.',
     )
     parser.add_argument(
+        '--model',
+        default=os.getenv('STT_MODEL') or 'whisper',
+        help=(
+            'Required remote STT model, for example large-v3. '
+            'Defaults to STT_MODEL or the generic whisper alias.'
+        ),
+    )
+    parser.add_argument(
         '--count',
         action='store_true',
         help='Count pending speech chunks eligible for STT and exit.',
@@ -667,7 +697,7 @@ if __name__ == '__main__':
 
     try:
         initialize_backend_auth()
-        configure_transcription_endpoint(args.server, args.api_key)
+        configure_transcription_endpoint(args.server, args.api_key, args.model)
     except Exception as e:
         print(f"Error initializing STT worker: {e}", file=sys.stderr)
         sys.exit(1)

--- a/python/tests/test_stt.py
+++ b/python/tests/test_stt.py
@@ -13,12 +13,17 @@ class RemoteTranscriptionTest(TestCase):
     def setUp(self):
         self.previous_server = stt.TRANSCRIPTION_SERVER_URL
         self.previous_key = stt.TRANSCRIPTION_API_KEY
+        self.previous_model = stt.TRANSCRIPTION_MODEL
         stt.TRANSCRIPTION_SERVER_URL = "http://stt.example"
         stt.TRANSCRIPTION_API_KEY = "test-key"
+        stt.TRANSCRIPTION_MODEL = "whisper"
+        stt.REPORTED_TRANSCRIPTION_MODELS.clear()
 
     def tearDown(self):
         stt.TRANSCRIPTION_SERVER_URL = self.previous_server
         stt.TRANSCRIPTION_API_KEY = self.previous_key
+        stt.TRANSCRIPTION_MODEL = self.previous_model
+        stt.REPORTED_TRANSCRIPTION_MODELS.clear()
 
     def test_records_model_from_proxy_header(self):
         response = MagicMock()
@@ -53,6 +58,30 @@ class RemoteTranscriptionTest(TestCase):
             transcript = stt.transcribe_with_remote_server(b"audio")
 
         self.assertEqual(transcript["metadata"]["model"], "medium")
+
+    def test_sends_and_verifies_requested_model(self):
+        stt.TRANSCRIPTION_MODEL = "large-v3"
+        response = MagicMock()
+        response.headers = {"X-Whisper-Model": "large-v3"}
+        response.json.return_value = {"segments": []}
+
+        with patch("stt.requests.post", return_value=response) as request:
+            transcript = stt.transcribe_with_remote_server(b"audio")
+
+        self.assertEqual(request.call_args.kwargs["data"], {"model": "large-v3"})
+        self.assertEqual(transcript["metadata"]["model"], "large-v3")
+
+    def test_rejects_model_mismatch(self):
+        stt.TRANSCRIPTION_MODEL = "large-v3"
+        response = MagicMock()
+        response.headers = {"X-Whisper-Model": "large-v3-turbo"}
+        response.json.return_value = {"segments": []}
+
+        with (
+            patch("stt.requests.post", return_value=response),
+            self.assertRaisesRegex(RuntimeError, "model mismatch"),
+        ):
+            stt.transcribe_with_remote_server(b"audio")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add `python stt.py --model <name>` and include the requested model in every remote request
- print the requested model at startup and the server-reported model when transcription begins
- reject requested/loaded model mismatches in both the Portainer proxy and worker
- document that model changes require an `ASR_MODEL` stack redeploy

## Verification

- 13 Python tests pass
- Python proxy and worker compile
- Portainer Compose configuration validates
- `git diff --check` passes
