### PR TITLE
Restore automatic remote STT pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -197,7 +197,8 @@ NODE_ENV=development
 # Set this to prevent faster-whisper language detection failures with short audio
 # TRANSCRIPTION_LANGUAGE=auto
 
-# STT_SERVER_URL - Remote OpenAI-compatible STT endpoint used only by python/stt.py
+# STT_SERVER_URL - Dedicated remote OpenAI-compatible STT endpoint used by the
+# automatic backend pipeline and by python/stt.py
 # Portainer is an admin UI; use the proxy's published host/Tailscale URL here.
 # Example: http://100.119.163.116:8001
 # STT_SERVER_URL=
@@ -206,9 +207,9 @@ NODE_ENV=development
 # Generate the same value for the GPU stack with: openssl rand -hex 32
 # PROXY_API_KEY=
 
-# STT_MODEL - Model required by python/stt.py and fallback provenance when a
-# remote STT server does not return X-Whisper-Model. The Mycelia Portainer proxy
-# validates this against its loaded ASR_MODEL and returns the header automatically.
+# STT_MODEL - Model requested by the automatic pipeline and python/stt.py.
+# The generic "whisper" alias accepts whichever model the server has loaded.
+# The Mycelia Portainer proxy reports its actual ASR_MODEL automatically.
 # STT_MODEL=large-v3-turbo
 
 # Model Configuration

--- a/README.md
+++ b/README.md
@@ -174,11 +174,57 @@ uv run daemon.py --once
 uv run daemon.py --reset-errors
 ```
 
+#### Run the Complete Automatic Pipeline
+
+The recommended end-to-end command is:
+
+```bash
+cd /path/to/mycelia
+./scripts/run-audio-pipeline.sh
+```
+
+It starts the Docker services and then runs local discovery/import on the host,
+where Apple Voice Memos and other local files are accessible. After each audio
+chunk is inserted, the backend automatically runs the remaining stages:
+
+```text
+daemon import -> VAD -> speech sequence creation -> remote STT -> conversations
+```
+
+The automatic transcription resource prefers the dedicated `STT_SERVER_URL`,
+`PROXY_API_KEY`, and optional `STT_MODEL` values from `.env`. If those dedicated
+variables are absent, it keeps the previous behavior and uses the inference
+provider configured in Mycelia Settings.
+
+Before running it, configure at least:
+
+```dotenv
+STT_SERVER_URL=http://100.119.163.116:8001
+PROXY_API_KEY=your-proxy-key
+STT_MODEL=whisper
+```
+
+Use the `whisper` alias when the Portainer stack should use whichever
+`ASR_MODEL` it has loaded. The service reports the actual model, and Mycelia
+stores it in `transcriptions.metadata.model`.
+
+Historically, `daemon.py` also performed only discovery and ingestion. VAD was
+not calculated inside that process: the backend change-stream trigger created a
+VAD job, `python-worker` calculated VAD, and later backend jobs created and
+transcribed speech sequences. In other words, the normal old startup was
+`docker compose up -d` plus `uv run daemon.py`; VAD appeared automatic because
+the Docker backend and worker were already running.
+
+`daemon.py --vad-only` and `stt.py` remain recovery/manual tools. Do not run
+them alongside a healthy automatic pipeline: direct STT can race the backend
+transcription jobs for the same chunks.
+
 #### Run Import and VAD in Parallel
 
-Use two terminals. Keep file discovery/import on the host so it can access your
-local recordings, and run VAD in the Python worker container where the Silero
-model and cache are already available.
+Use this recovery path only when the backend job queue is unavailable or
+blocked. Keep file discovery/import on the host so it can access your local
+recordings, and run VAD in the Python worker container where the Silero model
+and cache are already available.
 
 Terminal 1:
 
@@ -209,8 +255,8 @@ Do not start multiple VAD-only processes against the same database; the current
 Silero worker uses shared state within each process and VAD chunks are not
 claimed for multi-worker execution.
 
-After VAD marks speech chunks, inspect and run the separately configured STT
-worker:
+After VAD marks speech chunks, inspect and run the direct STT worker only if the
+automatic transcription queue is not running:
 
 ```bash
 docker compose exec -T python-worker python stt.py --count

--- a/backend/app/lib/jobs/maintenance-manager.ts
+++ b/backend/app/lib/jobs/maintenance-manager.ts
@@ -8,6 +8,13 @@ import { getQueue } from "./queue.ts";
 const JOB_TIMEOUT_MS = 15 * 60 * 1000;
 const MAINTENANCE_INTERVAL_MS = 60 * 1000;
 const WAITING_MISSING_GRACE_MS = 2 * 60 * 1000;
+const LIVE_QUEUE_STATES = new Set([
+  "active",
+  "delayed",
+  "prioritized",
+  "waiting",
+  "waiting-children",
+]);
 
 export class MaintenanceManager {
   private interval: number | null = null;
@@ -131,7 +138,28 @@ export class MaintenanceManager {
       const queue = getQueue(jobType);
       const queueJob = await queue.getJob(jobId);
       if (queueJob) {
-        continue;
+        const queueState = await queueJob.getState();
+        if (LIVE_QUEUE_STATES.has(queueState)) {
+          continue;
+        }
+
+        // Mongo can say "waiting" after the BullMQ job has already reached a
+        // terminal state (for example when the backend missed a Redis event).
+        // Remove that terminal queue record so the same stable job ID can be
+        // added again below.
+        try {
+          await queueJob.remove();
+          console.warn(
+            `[MaintenanceManager] Removed terminal ${queueState} queue record for waiting job ${jobId} in ${jobType}.`,
+          );
+        } catch (err) {
+          console.warn(
+            `[MaintenanceManager] Failed to remove terminal queue record ${jobId} in ${jobType}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+          continue;
+        }
       }
 
       try {

--- a/backend/app/lib/transcription/resource.server.test.ts
+++ b/backend/app/lib/transcription/resource.server.test.ts
@@ -1,0 +1,87 @@
+import { expect } from "@std/expect";
+import { TranscriptionResource } from "./resource.server.ts";
+import type { Auth } from "@/lib/auth/core.server.ts";
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    Deno.env.delete(name);
+  } else {
+    Deno.env.set(name, value);
+  }
+}
+
+Deno.test("dedicated STT environment drives transcription and records the reported model", async () => {
+  const previous = {
+    url: Deno.env.get("STT_SERVER_URL"),
+    key: Deno.env.get("PROXY_API_KEY"),
+    model: Deno.env.get("STT_MODEL"),
+  };
+
+  Deno.env.set("STT_SERVER_URL", "http://stt.example:8001/");
+  Deno.env.set("PROXY_API_KEY", "test-key");
+  Deno.env.set("STT_MODEL", "whisper");
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    expect(String(input)).toBe(
+      "http://stt.example:8001/v1/audio/transcriptions",
+    );
+    expect(
+      (init?.headers as Record<string, string>).Authorization,
+    ).toBe("Bearer test-key");
+    expect((init?.body as FormData).get("model")).toBe("whisper");
+    expect((init?.body as FormData).get("language")).toBe(null);
+
+    return new Response(JSON.stringify({ text: "hello", segments: [] }), {
+      headers: { "X-Whisper-Model": "large-v3-turbo" },
+    });
+  };
+
+  try {
+    const resource = new TranscriptionResource();
+    const result = await resource.use({
+      action: "transcribe",
+      file: new Uint8Array([1, 2, 3]),
+      fileName: "sample.wav",
+      fileType: "audio/wav",
+      language: "auto",
+    }, {} as Auth) as Record<string, any>;
+
+    expect(result.metadata).toEqual({
+      model: "large-v3-turbo",
+      provider: "remote_openai_compatible",
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreEnv("STT_SERVER_URL", previous.url);
+    restoreEnv("PROXY_API_KEY", previous.key);
+    restoreEnv("STT_MODEL", previous.model);
+  }
+});
+
+Deno.test("dedicated STT configuration rejects a missing proxy key", async () => {
+  const previousUrl = Deno.env.get("STT_SERVER_URL");
+  const previousKey = Deno.env.get("PROXY_API_KEY");
+
+  Deno.env.set("STT_SERVER_URL", "http://stt.example:8001");
+  Deno.env.delete("PROXY_API_KEY");
+
+  try {
+    const resource = new TranscriptionResource();
+    let message = "";
+    try {
+      await resource.getInferenceProvider();
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toBe(
+      "STT_SERVER_URL and PROXY_API_KEY must both be set for dedicated STT.",
+    );
+  } finally {
+    restoreEnv("STT_SERVER_URL", previousUrl);
+    restoreEnv("PROXY_API_KEY", previousKey);
+  }
+});

--- a/backend/app/lib/transcription/resource.server.ts
+++ b/backend/app/lib/transcription/resource.server.ts
@@ -28,7 +28,30 @@ export class TranscriptionResource implements Resource<TranscriptionRequest, Tra
     response: z.any() as z.ZodType<TranscriptionResponse>,
   };
 
-  async getInferenceProvider(): Promise<{ baseUrl: string; apiKey: string } | null> {
+  async getInferenceProvider(): Promise<{
+    baseUrl: string;
+    apiKey: string;
+    model?: string;
+    source: "stt_env" | "inference_config";
+  } | null> {
+    const sttBaseUrl = Deno.env.get("STT_SERVER_URL")?.trim();
+    const sttApiKey = Deno.env.get("PROXY_API_KEY")?.trim();
+
+    if (sttBaseUrl || sttApiKey) {
+      if (!sttBaseUrl || !sttApiKey) {
+        throw new Error(
+          "STT_SERVER_URL and PROXY_API_KEY must both be set for dedicated STT.",
+        );
+      }
+
+      return {
+        baseUrl: sttBaseUrl,
+        apiKey: sttApiKey,
+        model: Deno.env.get("STT_MODEL")?.trim() || "whisper",
+        source: "stt_env",
+      };
+    }
+
     const config = await getServerConfig();
     const inference = config.inference;
     if (!inference?.baseUrl || !inference?.apiKey) {
@@ -37,6 +60,7 @@ export class TranscriptionResource implements Resource<TranscriptionRequest, Tra
     return {
       baseUrl: inference.baseUrl,
       apiKey: inference.apiKey,
+      source: "inference_config",
     };
   }
 
@@ -87,13 +111,16 @@ export class TranscriptionResource implements Resource<TranscriptionRequest, Tra
           const fileName = input.fileName || "audio.mp3";
           const file = new File([blob], fileName, { type: input.fileType || "audio/mpeg" });
           formData.append("file", file);
-          if (input.language) {
+          // OpenAI-compatible Whisper servers auto-detect language when the
+          // field is omitted. Some faster-whisper servers reject the literal
+          // value "auto" with a 500 response.
+          if (input.language && input.language !== "auto") {
             formData.append("language", input.language);
           }
           if (input.prompt) {
             formData.append("prompt", input.prompt);
           }
-          formData.append("model", "whisper");
+          formData.append("model", provider.model || "whisper");
 
           const proxyResponse = await fetch(
             provider.baseUrl.replace(/\/$/, "") + "/v1/audio/transcriptions",
@@ -124,6 +151,20 @@ export class TranscriptionResource implements Resource<TranscriptionRequest, Tra
 
           try {
             const jsonResponse = JSON.parse(responseText);
+            const reportedModel = proxyResponse.headers.get("X-Whisper-Model")
+              || provider.model
+              || "unknown";
+            const responseMetadata = jsonResponse.metadata
+              && typeof jsonResponse.metadata === "object"
+              ? jsonResponse.metadata
+              : {};
+            jsonResponse.metadata = {
+              ...responseMetadata,
+              model: reportedModel,
+              provider: provider.source === "stt_env"
+                ? "remote_openai_compatible"
+                : "configured_inference",
+            };
             span.setStatus({ code: 1 });
             return jsonResponse;
           } catch (parseError) {
@@ -166,4 +207,3 @@ export async function getTranscriptionResource(
 ): Promise<(input: TranscriptionRequest) => Promise<TranscriptionResponse>> {
   return auth.getResource("transcription");
 }
-

--- a/backend/workers/transcription.ts
+++ b/backend/workers/transcription.ts
@@ -221,6 +221,10 @@ const capability: JobCapability = {
         // Calculate word count
         const wordCount = transcriptionText.split(/\s+/).filter((w: string) => w.length > 0).length;
 
+        const responseMetadata = (transcript as any).metadata
+          && typeof (transcript as any).metadata === "object"
+          ? (transcript as any).metadata
+          : {};
         const transcriptionDoc = {
           original: sequence.original_id,
           start: sequence.start,
@@ -231,7 +235,8 @@ const capability: JobCapability = {
           createdAt: new Date(),
           // Metadata for display
           metadata: {
-            model: "whisper",
+            ...responseMetadata,
+            model: responseMetadata.model || "whisper",
             processingTimeMs: transcriptDuration,
             wordCount,
             segmentCount: filteredSegments.length,

--- a/scripts/run-audio-pipeline.sh
+++ b/scripts/run-audio-pipeline.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+env_file="${repo_root}/.env"
+pipeline_venv="${UV_PROJECT_ENVIRONMENT:-/private/tmp/mycelia-daemon-venv}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required" >&2
+  exit 1
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv is required" >&2
+  exit 1
+fi
+
+if [[ ! -f "${env_file}" ]]; then
+  echo "Missing ${env_file}; copy .env.example to .env and configure it first." >&2
+  exit 1
+fi
+
+if ! grep -Eq '^STT_SERVER_URL=.+$' "${env_file}"; then
+  echo "STT_SERVER_URL is missing from ${env_file}" >&2
+  exit 1
+fi
+
+if ! grep -Eq '^PROXY_API_KEY=.+$' "${env_file}"; then
+  echo "PROXY_API_KEY is missing from ${env_file}" >&2
+  exit 1
+fi
+
+echo "Starting Mycelia services and the automatic audio pipeline..."
+docker compose --project-directory "${repo_root}" up -d
+
+echo "Starting host audio discovery/import. Press Ctrl+C to stop importing."
+echo "VAD and transcription continue automatically in the Docker services."
+cd "${repo_root}/python"
+exec env UV_PROJECT_ENVIRONMENT="${pipeline_venv}" uv run daemon.py "$@"


### PR DESCRIPTION
## What changed

- recover Mongo `waiting` jobs when their BullMQ records are already terminal
- route the automatic backend transcription pipeline through `STT_SERVER_URL` and `PROXY_API_KEY`
- omit the unsupported literal `language=auto` from OpenAI-compatible STT requests
- preserve the model reported by the STT proxy in transcription metadata
- add a one-command host import and automatic processing launcher
- document the historical automatic VAD/transcription flow and the direct recovery tools

## Why

Old Mongo job records could permanently consume a worker's single concurrency slot even though their BullMQ jobs had already failed or completed. Once recovered, the backend transcription request reached the dedicated faster-whisper service but failed because it sent `language=auto`, which that endpoint rejected.

## Impact

`./scripts/run-audio-pipeline.sh` starts Mycelia and the host importer. Newly ingested chunks then advance automatically through VAD, speech sequence creation, the remote STT service, and conversation processing. Direct `daemon.py --vad-only` and `stt.py` remain recovery tools.

## Validation

- `deno check app/lib/jobs/maintenance-manager.ts app/lib/transcription/resource.server.ts workers/transcription.ts`
- `deno test -A app/lib/transcription/resource.server.test.ts` (2 passed)
- `UV_PROJECT_ENVIRONMENT=/private/tmp/mycelia-daemon-venv uv run python -m unittest discover -s tests -v` (13 passed)
- `bash -n scripts/run-audio-pipeline.sh`
- live recovery of stale VAD, sequence, and transcription jobs
- live remote STT transcription saved with `metadata.model=large-v3` and `metadata.provider=remote_openai_compatible`
