### PR TITLE
Improve job recovery and result navigation

### DIFF
--- a/backend/app/lib/jobs/processor.ts
+++ b/backend/app/lib/jobs/processor.ts
@@ -3,10 +3,23 @@ import type { JobData, JobResult } from "./types.ts";
 import { jobRegistry } from "./job-registry.ts";
 import { signJWT } from "@/lib/auth/tokens.ts";
 import { getServerAuth } from "@/lib/auth/core.server.ts";
-import { EJSON } from "bson";
+import { EJSON, ObjectId } from "bson";
 import { getMongoResource } from "@/lib/mongo/core.server.ts";
 
 const JOB_TIMEOUT_MS = 15 * 60 * 1000;
+const activeChildren = new Map<string, Deno.ChildProcess>();
+
+export function cancelRunningJob(jobId: string): boolean {
+  const child = activeChildren.get(jobId);
+  if (!child) return false;
+
+  try {
+    child.kill("SIGKILL");
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export async function processJob(job: Job<JobData>): Promise<JobResult> {
   const jobType = job.data.type;
@@ -96,6 +109,7 @@ export async function processJob(job: Job<JobData>): Promise<JobResult> {
   });
 
   const child = cmd.spawn();
+  if (job.id) activeChildren.set(job.id, child);
   let timeoutId: number | null = null;
 
   const mongo = await getMongoResource(await getServerAuth());
@@ -221,7 +235,7 @@ export async function processJob(job: Job<JobData>): Promise<JobResult> {
   };
 
   try {
-    return await Promise.race([
+    const result = await Promise.race([
       runChild(),
       new Promise<never>((_resolve, reject) => {
         timeoutId = setTimeout(() => {
@@ -234,7 +248,58 @@ export async function processJob(job: Job<JobData>): Promise<JobResult> {
         }, JOB_TIMEOUT_MS);
       }),
     ]);
+
+    // Persist completion here as well as in QueueEvents. An active BullMQ job
+    // cannot be force-removed safely: its worker may still finish and commit
+    // side effects after the queue record was cancelled/removed. In that case
+    // BullMQ may never emit the global completed event, so Mongo would
+    // otherwise remain incorrectly marked as cancelled.
+    const jobDocs = await mongo({
+      action: "find",
+      collection: "jobs",
+      query: { _id: new ObjectId(job.id) },
+      options: { limit: 1 },
+    });
+    const previousState = jobDocs[0]?.state;
+    const finishedAt = new Date();
+
+    if (previousState === "cancelled") {
+      console.warn(
+        `[Processor] Job ${job.id} produced a result after cancellation; ` +
+          "reconciling Mongo state to completed",
+      );
+    }
+
+    await mongo({
+      action: "updateOne",
+      collection: "jobs",
+      query: { _id: new ObjectId(job.id) },
+      update: {
+        $set: {
+          state: "completed",
+          finishedAt,
+          result,
+          updatedAt: finishedAt,
+          ...(previousState === "cancelled"
+            ? {
+              completionReconciliation: {
+                previousState,
+                reconciledAt: finishedAt,
+                reason: "worker_completed_after_cancellation",
+              },
+            }
+            : {}),
+        },
+        $unset: {
+          failedReason: "",
+          cancelReason: "",
+        },
+      },
+    });
+
+    return result;
   } finally {
+    if (job.id) activeChildren.delete(job.id);
     if (timeoutId !== null) {
       clearTimeout(timeoutId);
     }

--- a/backend/app/lib/jobs/processor.ts
+++ b/backend/app/lib/jobs/processor.ts
@@ -110,7 +110,7 @@ export async function processJob(job: Job<JobData>): Promise<JobResult> {
 
   const child = cmd.spawn();
   if (job.id) activeChildren.set(job.id, child);
-  let timeoutId: number | null = null;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
   const mongo = await getMongoResource(await getServerAuth());
   let logQueue = Promise.resolve();

--- a/backend/app/lib/jobs/tests/clear-queue.test.ts
+++ b/backend/app/lib/jobs/tests/clear-queue.test.ts
@@ -16,6 +16,19 @@ Deno.test("clear_queue requires cancel permission for one worker type", () => {
   }]);
 });
 
+Deno.test("reset_worker requires scoped lifecycle permissions", () => {
+  const resource = new JobsResource();
+
+  expect(resource.extractActions({
+    action: "reset_worker",
+    workerType: "summarization",
+    restart: true,
+  })).toEqual([{
+    path: ["jobs", "summarization"],
+    actions: ["cancel", "pause", "resume", "enqueue"],
+  }]);
+});
+
 Deno.test("clear_failed requires delete permission for one worker type", () => {
   const resource = new JobsResource();
 

--- a/backend/app/lib/jobs/workers.ts
+++ b/backend/app/lib/jobs/workers.ts
@@ -36,6 +36,24 @@ export async function startWorkers() {
       const auth = await getServerAuth();
       const mongo = await getMongoResource(auth);
       const startedAt = new Date();
+      const existingJobs = await mongo({
+        action: "find",
+        collection: "jobs",
+        query: { _id: new ObjectId(jobId) },
+        options: { limit: 1 },
+      });
+      const existingJob = existingJobs[0];
+      const isRestart = (existingJob?.attempts ?? 0) > 0 ||
+        existingJob?.finishedAt != null;
+
+      if (isRestart) {
+        console.warn(
+          `[${jobType}] Job ${jobId} restarted: clearing stale terminal data ` +
+            `(previous state=${existingJob?.state ?? "unknown"}, ` +
+            `attempts=${existingJob?.attempts ?? 0})`,
+        );
+      }
+
       await mongo({
         action: "updateOne",
         collection: "jobs",
@@ -44,15 +62,33 @@ export async function startWorkers() {
           $set: { 
             state: "active", 
             startedAt,
-            updatedAt: new Date() 
+            updatedAt: new Date(),
+            ...(isRestart
+              ? {
+                restartInfo: {
+                  detectedAt: startedAt,
+                  previousState: existingJob?.state,
+                  previousStartedAt: existingJob?.startedAt,
+                  previousFinishedAt: existingJob?.finishedAt,
+                  attempt: (existingJob?.attempts ?? 0) + 1,
+                },
+              }
+              : {}),
           },
-          $inc: { attempts: 1 }
+          $inc: { attempts: 1 },
+          $unset: {
+            finishedAt: "",
+            failedReason: "",
+            result: "",
+            cancelReason: "",
+          },
         },
       });
 
       await publishJobUpdate(jobId, jobType, "job.active", {
         state: "active",
         processedOn: startedAt.getTime(),
+        restarted: isRestart,
       });
     });
 
@@ -86,7 +122,51 @@ export async function startWorkers() {
       console.error(`[${jobType}] Job ${jobId} failed globally:`, failedReason);
       const auth = await getServerAuth();
       const mongo = await getMongoResource(auth);
+      const existingJobs = await mongo({
+        action: "find",
+        collection: "jobs",
+        query: { _id: new ObjectId(jobId) },
+        options: { limit: 1 },
+      });
+      if (existingJobs[0]?.state === "cancelled") {
+        console.log(
+          `[${jobType}] Job ${jobId} was cancelled; preserving cancelled state after worker exit`,
+        );
+        return;
+      }
       const finishedAt = new Date();
+      let partialResult: Record<string, unknown> | undefined;
+
+      if (jobType === "summarization") {
+        const savedSummaryStats = await mongo({
+          action: "aggregate",
+          collection: "objects",
+          pipeline: [
+            { $match: { "summaries.jobId": jobId } },
+            { $unwind: "$summaries" },
+            { $match: { "summaries.jobId": jobId } },
+            {
+              $group: {
+                _id: null,
+                summariesSaved: { $sum: 1 },
+                lastSummaryAt: { $max: "$summaries.date" },
+              },
+            },
+            { $project: { _id: 0 } },
+          ],
+        });
+        if ((savedSummaryStats[0]?.summariesSaved ?? 0) > 0) {
+          partialResult = {
+            ...savedSummaryStats[0],
+            reason: "summaries_saved_before_job_failure",
+          };
+          console.warn(
+            `[${jobType}] Job ${jobId} failed after saving ` +
+              `${savedSummaryStats[0].summariesSaved} summary result(s)`,
+          );
+        }
+      }
+
       await mongo({
         action: "updateOne",
         collection: "jobs",
@@ -96,7 +176,8 @@ export async function startWorkers() {
             state: "failed", 
             finishedAt,
             failedReason: failedReason,
-            updatedAt: new Date() 
+            updatedAt: new Date(),
+            ...(partialResult ? { partialResult } : {}),
           } 
         },
       });
@@ -116,11 +197,19 @@ export async function startWorkers() {
       console.log(`[${jobType}] Local worker completed job ${job.id}`);
       console.log(`[${jobType}] Job ${job.id} result:`, JSON.stringify(job.returnvalue));
 
-      if (job.returnvalue?.hasMore === true) {
+      if (
+        job.returnvalue?.hasMore === true &&
+        typeof job.returnvalue?.processed === "number" &&
+        job.returnvalue.processed > 0
+      ) {
         console.log(`[${jobType}] Scheduling another job for ${job.data.type} because hasMore is true`);
         enqueueJob(job.data, {
           trigger: { type: "auto", reason: "hasMore" },
         });
+      } else if (job.returnvalue?.hasMore === true) {
+        console.warn(
+          `[${jobType}] Not scheduling another job because this batch made no progress`,
+        );
       }
     });
 

--- a/backend/app/lib/mongo/changeStream.worker.ts
+++ b/backend/app/lib/mongo/changeStream.worker.ts
@@ -24,12 +24,14 @@ async function publishMongoChange(
   operationType: string,
   documentId: string,
   document?: any,
+  updateDescription?: unknown,
 ): Promise<void> {
   const eventData = {
     collection: collectionName,
     operationType,
     documentId,
     document,
+    updateDescription,
     timestamp: new Date().toISOString(),
   };
 
@@ -89,6 +91,7 @@ export async function startChangeStreamWorker(): Promise<void> {
             const operationType = change.operationType;
             let documentId: string;
             let document: any = null;
+            let updateDescription: unknown;
 
             switch (operationType) {
               case "insert":
@@ -96,6 +99,10 @@ export async function startChangeStreamWorker(): Promise<void> {
                 document = change.fullDocument;
                 break;
               case "update":
+                updateDescription = change.updateDescription;
+                documentId = getDocumentId(change.documentKey);
+                document = change.fullDocument;
+                break;
               case "replace":
                 documentId = getDocumentId(change.documentKey);
                 document = change.fullDocument;
@@ -110,7 +117,13 @@ export async function startChangeStreamWorker(): Promise<void> {
                 return;
             }
 
-            await publishMongoChange(collectionName, operationType, documentId, document);
+            await publishMongoChange(
+              collectionName,
+              operationType,
+              documentId,
+              document,
+              updateDescription,
+            );
           } catch (error) {
             console.error(`[ChangeStream] Error processing change for ${collectionName}:`, error);
           }
@@ -152,4 +165,3 @@ export async function stopChangeStreamWorker(): Promise<void> {
     await changeStreamWorker.stop();
   }
 }
-

--- a/backend/app/lib/resources/worker.ts
+++ b/backend/app/lib/resources/worker.ts
@@ -8,6 +8,7 @@ import { enqueueJob, EnqueueJobOptions, getQueue } from "@/lib/jobs/queue.ts";
 import { publishJobUpdate } from "@/lib/events/publisher.ts";
 import { workerPauseManager } from "@/lib/jobs/worker-pause-manager.ts";
 import { getConfigResource } from "@/lib/config/resource.server.ts";
+import { cancelRunningJob } from "@/lib/jobs/processor.ts";
 
 const UpdateProgressSchema = z.object({
   action: z.literal("progressUpdate"),
@@ -50,6 +51,12 @@ const ClearFailedJobsSchema = z.object({
 const ClearQueueSchema = z.object({
   action: z.literal("clear_queue"),
   workerType: z.string(),
+});
+
+const ResetWorkerSchema = z.object({
+  action: z.literal("reset_worker"),
+  workerType: z.string(),
+  restart: z.boolean().optional().default(false),
 });
 
 const CancelJobSchema = z.object({
@@ -124,6 +131,7 @@ const RequestSchema = z.union([
   ClearCompletedJobsSchema,
   ClearFailedJobsSchema,
   ClearQueueSchema,
+  ResetWorkerSchema,
   CancelJobSchema,
   GetJobSchema,
   EnqueueJobSchema,
@@ -174,6 +182,8 @@ export class JobsResource
         return this.clearFailed(input, auth);
       case "clear_queue":
         return this.clearQueue(input, auth);
+      case "reset_worker":
+        return this.resetWorker(input, auth);
       case "list":
         return this.list(input, auth);
       case "progressUpdate":
@@ -222,6 +232,16 @@ export class JobsResource
       throw new Error(`Job ${input.id} not found`);
     }
 
+    const queueJob = await getQueue(job.type).getJob(input.id);
+    let queueState: string | null = null;
+    if (queueJob) {
+      try {
+        queueState = await queueJob.getState();
+      } catch {
+        queueState = "unknown";
+      }
+    }
+
     return {
       id: job._id.toString(),
       type: job.type,
@@ -234,6 +254,10 @@ export class JobsResource
       finishedOn: job.finishedAt?.getTime(),
       processedOn: job.startedAt?.getTime(),
       failedReason: job.failedReason,
+      restarted: job.restartInfo != null,
+      updatedOn: job.updatedAt?.getTime(),
+      queueState,
+      queuePresent: queueJob != null,
     };
   }
 
@@ -269,6 +293,7 @@ export class JobsResource
     }
 
     const jobType = jobDoc.type as string;
+    const wasActive = jobDoc.state === "active";
     const queue = getQueue(jobType);
     const job = await queue.getJob(id);
 
@@ -284,50 +309,80 @@ export class JobsResource
       }
     }
 
-    await mongo({
+    const cancelResult = await mongo({
       action: "updateOne",
       collection: "jobs",
-      query: { _id: new ObjectId(id) },
+      query: {
+        _id: new ObjectId(id),
+        state: { $in: ["waiting", "active", "delayed"] },
+      },
       update: {
         $set: {
           state: "cancelled",
+          cancelReason: "user_cancelled",
           finishedAt: new Date(),
           updatedAt: new Date(),
         },
       },
     });
+
+    if ((cancelResult.modifiedCount ?? 0) === 0) {
+      console.warn(
+        `[jobs] Job ${id} reached a terminal state before cancellation could be recorded`,
+      );
+      return { success: true, cancelled: false };
+    }
+
+    const processTerminated = wasActive ? cancelRunningJob(id) : false;
+
+    if (jobType === "summarization") {
+      await mongo({
+        action: "updateMany",
+        collection: "objects",
+        query: { "_summarizationClaim.jobId": id },
+        update: { $unset: { _summarizationClaim: "" } },
+      });
+    }
 
     await publishJobUpdate(id, jobType, "job.state", {
       state: "cancelled",
       finishedOn: Date.now(),
     });
 
-    return { success: true };
+    return { success: true, cancelled: true, processTerminated };
   }
 
   private async cancelAll(_input: z.infer<typeof CancelAllJobsSchema>, auth: Auth) {
     const mongo = await getMongoResource(auth);
 
+    // Never force-remove active BullMQ jobs: their processors keep running
+    // without a lock and later surface as stalled, even after committing side
+    // effects. Drain only jobs that have not started; active work completes.
     const types = jobRegistry.getJobTypes();
     for (const type of types) {
       const queue = getQueue(type);
-      await queue.obliterate({ force: true });
+      await queue.drain(true);
     }
 
-    await mongo({
+    const result = await mongo({
       action: "updateMany",
       collection: "jobs",
-      query: { state: { $in: ["waiting", "active", "delayed"] } },
+      query: { state: { $in: ["waiting", "delayed"] } },
       update: {
         $set: {
           state: "cancelled",
+          cancelReason: "all_queues_cleared",
           finishedAt: new Date(),
           updatedAt: new Date(),
         },
       },
     });
 
-    return { success: true };
+    return {
+      success: true,
+      cancelledCount: result.modifiedCount ?? 0,
+      activeJobsContinued: true,
+    };
   }
 
   private async clearCompleted(_input: z.infer<typeof ClearCompletedJobsSchema>, auth: Auth) {
@@ -411,6 +466,94 @@ export class JobsResource
     };
   }
 
+  private async resetWorker(
+    input: z.infer<typeof ResetWorkerSchema>,
+    auth: Auth,
+  ) {
+    const { workerType, restart } = input;
+    const types = jobRegistry.getJobTypes();
+    if (!types.includes(workerType)) {
+      throw new Error(`Unknown worker type: ${workerType}`);
+    }
+
+    // Pause first so draining the queue cannot race with a worker taking the
+    // next waiting job.
+    await workerPauseManager.pauseWorker(workerType);
+    await this.persistWorkerConfig(workerType, { paused: true }, auth);
+
+    const mongo = await getMongoResource(auth);
+    const liveJobs = await mongo({
+      action: "find",
+      collection: "jobs",
+      query: {
+        type: workerType,
+        state: { $in: ["active", "waiting", "delayed"] },
+      },
+      options: { limit: 5000 },
+    });
+
+    const queue = getQueue(workerType);
+    await queue.drain(true);
+
+    let terminatedCount = 0;
+    for (const job of liveJobs) {
+      if (job.state === "active" && cancelRunningJob(job._id.toString())) {
+        terminatedCount++;
+      }
+    }
+
+    const now = new Date();
+    const cancelled = await mongo({
+      action: "updateMany",
+      collection: "jobs",
+      query: {
+        type: workerType,
+        state: { $in: ["active", "waiting", "delayed"] },
+      },
+      update: {
+        $set: {
+          state: "cancelled",
+          cancelReason: "worker_reset",
+          finishedAt: now,
+          updatedAt: now,
+        },
+      },
+    });
+
+    let claimsCleared = 0;
+    if (workerType === "summarization") {
+      const claimResult = await mongo({
+        action: "updateMany",
+        collection: "objects",
+        query: { "_summarizationClaim.jobId": { $exists: true } },
+        update: { $unset: { _summarizationClaim: "" } },
+      });
+      claimsCleared = claimResult.modifiedCount ?? 0;
+    }
+
+    let restartedJobId: string | undefined;
+    if (restart) {
+      const newJob = await enqueueJob(
+        { type: workerType },
+        { trigger: { type: "manual", reason: "worker_reset" } },
+        await getServerAuth(),
+      );
+      restartedJobId = newJob.id;
+      await workerPauseManager.resumeWorker(workerType);
+      await this.persistWorkerConfig(workerType, { paused: false }, auth);
+    }
+
+    return {
+      success: true,
+      workerType,
+      cancelledCount: cancelled.modifiedCount ?? 0,
+      terminatedCount,
+      claimsCleared,
+      restartedJobId,
+      paused: !restart,
+    };
+  }
+
   private async list(input: z.infer<typeof ListJobsSchema>, auth: Auth) {
     const mongo = await getMongoResource(auth);
     
@@ -445,6 +588,7 @@ export class JobsResource
       finishedOn: job.finishedAt?.getTime(),
       processedOn: job.startedAt?.getTime(),
       failedReason: job.failedReason,
+      restarted: job.restartInfo != null,
     }));
   }
 
@@ -592,6 +736,7 @@ export class JobsResource
 
   private async stats(auth: Auth) {
     const mongo = await getMongoResource(auth);
+    const staleCutoff = new Date(Date.now() - 15 * 60 * 1000);
     // TODO: worker specific logic should belong to the worker file
 
     // Get overall counts by status (across ALL jobs, not limited)
@@ -635,6 +780,16 @@ export class JobsResource
           totalRuns: { $sum: 1 },
           active: {
             $sum: { $cond: [{ $eq: ["$state", "active"] }, 1, 0] }
+          },
+          staleActive: {
+            $sum: {
+              $cond: [{
+                $and: [
+                  { $eq: ["$state", "active"] },
+                  { $lte: ["$startedAt", staleCutoff] },
+                ],
+              }, 1, 0],
+            },
           },
           waiting: {
             $sum: { $cond: [{ $eq: ["$state", "waiting"] }, 1, 0] }
@@ -761,6 +916,16 @@ export class JobsResource
     });
 
     // Calculate frequency from timestamps
+    const staleClaims = await mongo({
+      action: "count",
+      collection: "objects",
+      query: {
+        "_summarizationClaim.startedAt": {
+          $lte: staleCutoff.toISOString(),
+        },
+      },
+    }) as number;
+
     const result = stats.map((stat: any) => {
       const timestamps = stat.recentTimestamps || [];
       let avgFrequency = "-";
@@ -782,6 +947,8 @@ export class JobsResource
         type: stat.type,
         totalRuns: stat.totalRuns ?? 0,
         active: stat.active ?? 0,
+        staleActive: stat.staleActive ?? 0,
+        staleClaims: stat.type === "summarization" ? staleClaims : 0,
         waiting: stat.waiting ?? 0,
         delayed: stat.delayed ?? 0,
         completed: stat.completed ?? 0,
@@ -870,6 +1037,11 @@ export class JobsResource
         }];
       case "clear_queue":
         return [{ path: ["jobs", input.workerType], actions: ["cancel"] }];
+      case "reset_worker":
+        return [{
+          path: ["jobs", input.workerType],
+          actions: ["cancel", "pause", "resume", "enqueue"],
+        }];
       case "cancel":
         return [{ path: ["jobs", input.id], actions: ["cancel"] }];
       case "enqueue":

--- a/backend/workers/summarization.ts
+++ b/backend/workers/summarization.ts
@@ -567,6 +567,7 @@ export async function use(job: Job<JobData>): Promise<JobResult> {
 
   let processed = 0;
   let skipped = 0;
+  const summaries: Array<{ objectId: string; title?: string }> = [];
   const jobId = job.id ?? "unknown";
 
   for (const target of targets) {
@@ -584,6 +585,9 @@ export async function use(job: Job<JobData>): Promise<JobResult> {
       const result = await processConversation(job, jobData, target, jwt, myceliaUrl);
       if (result.success) {
         processed++;
+        if (typeof result.objectId === "string" && typeof result.title === "string") {
+          summaries.push({ objectId: result.objectId, title: result.title });
+        }
       } else {
         skipped++;
       }
@@ -596,11 +600,18 @@ export async function use(job: Job<JobData>): Promise<JobResult> {
     }
   }
 
-  return { success: processed > 0, processed, skipped, hasMore: hasMore ?? false };
+  return {
+    success: processed > 0,
+    processed,
+    skipped,
+    summaries,
+    hasMore: hasMore ?? false,
+  };
 }
 
 const capability: JobCapability = {
   name,
+  maxConcurrency: 1,
   inputSchema: z.toJSONSchema(schema),
   outputSchema: z.toJSONSchema(z.object({
     success: z.boolean(),
@@ -611,6 +622,10 @@ const capability: JobCapability = {
     description: z.string().optional(),
     processed: z.number().optional(),
     skipped: z.number().optional(),
+    summaries: z.array(z.object({
+      objectId: z.string(),
+      title: z.string().optional(),
+    })).optional(),
     hasMore: z.boolean().optional(),
     message: z.string().optional(),
   })),

--- a/backend/workers/summarization.ts
+++ b/backend/workers/summarization.ts
@@ -589,6 +589,9 @@ export async function use(job: Job<JobData>): Promise<JobResult> {
           summaries.push({ objectId: result.objectId, title: result.title });
         }
       } else {
+        if (target.objectId) {
+          await releaseClaim(target.objectId, jwt, myceliaUrl);
+        }
         skipped++;
       }
     } catch (error) {
@@ -642,9 +645,20 @@ const capability: JobCapability = {
         name: "conversation_missing_summary",
         filter: {
           event: "mongo.change",
-          "data.operationType": { $in: ["insert", "update"] },
           "data.document.isConversation": true,
           "data.document.summaries.0": { $exists: false },
+          $or: [
+            { "data.operationType": "insert" },
+            {
+              "data.operationType": "update",
+              "data.updateDescription.updatedFields._summarizationClaim": {
+                $exists: false,
+              },
+              "data.updateDescription.removedFields": {
+                $nin: ["_summarizationClaim"],
+              },
+            },
+          ],
         },
       },
     ],

--- a/frontend/src/components/SummarySection.tsx
+++ b/frontend/src/components/SummarySection.tsx
@@ -17,11 +17,12 @@ import type { Object } from "@/types/objects";
 
 interface SummarySectionProps {
   object: Object;
+  summaryJobId?: string | null;
   onSummaryClick?: (summary: NonNullable<Object["summaries"]>[number]) => void;
   onStarSummary?: (index: number) => void;
 }
 
-export function SummarySection({ object, onSummaryClick, onStarSummary }: SummarySectionProps) {
+export function SummarySection({ object, summaryJobId, onSummaryClick, onStarSummary }: SummarySectionProps) {
   const [isSummarizeOpen, setIsSummarizeOpen] = useState(false);
   const [isCompareOpen, setIsCompareOpen] = useState(false);
 
@@ -45,9 +46,16 @@ export function SummarySection({ object, onSummaryClick, onStarSummary }: Summar
 
   // Reset to starred or latest summary when summaries array changes
   useEffect(() => {
+    if (summaryJobId) {
+      const linkedIndex = summaries.findIndex((summary) => summary.jobId === summaryJobId);
+      if (linkedIndex !== -1) {
+        setCurrentIndex(linkedIndex);
+        return;
+      }
+    }
     const starredIndex = summaries.findIndex((s) => s.starred);
     setCurrentIndex(starredIndex !== -1 ? starredIndex : (summaries.length > 0 ? summaries.length - 1 : 0));
-  }, [summaries.length, summaries]);
+  }, [summaries.length, summaries, summaryJobId]);
 
   const goToPrevious = () => {
     setCurrentIndex((prev) => (prev > 0 ? prev - 1 : summaries.length - 1));

--- a/frontend/src/hooks/useJobsListener.ts
+++ b/frontend/src/hooks/useJobsListener.ts
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { useNavigate } from "react-router-dom";
 import type { JobInfo } from "@/types/jobs";
 import { useNotificationStore } from "@/stores/notificationStore";
-import { buildSummarizationCompletionNotification } from "@/lib/jobNotifications";
+import { buildSummarizationCompletionNotifications } from "@/lib/jobNotifications";
 
 /** Format job type for display */
 function formatJobType(type: string): string {
@@ -93,6 +93,7 @@ export function useJobsListener(options: UseJobsListenerOptions = {}) {
         timestamp?: number;
         processedOn?: number;
         finishedOn?: number;
+        restarted?: boolean;
       };
 
       if (!jobData?.jobId) return;
@@ -116,7 +117,11 @@ export function useJobsListener(options: UseJobsListenerOptions = {}) {
             processedOn = Date.now();
           }
 
-          let finishedOn = jobData.finishedOn ?? existing.finishedOn;
+          const isRunning = newState === "active" ||
+            event.event === "job.active" || event.event === "job.started";
+          let finishedOn = isRunning
+            ? undefined
+            : jobData.finishedOn ?? existing.finishedOn;
           if (!finishedOn && (event.event === "job.completed" || event.event === "job.failed" || newState === "completed" || newState === "failed")) {
             finishedOn = Date.now();
           }
@@ -125,10 +130,13 @@ export function useJobsListener(options: UseJobsListenerOptions = {}) {
             ...existing,
             state: newState,
             progress: jobData.progress ?? existing.progress,
-            result: jobData.result ?? existing.result,
-            failedReason: jobData.failedReason ?? existing.failedReason,
+            result: isRunning ? undefined : jobData.result ?? existing.result,
+            failedReason: isRunning
+              ? undefined
+              : jobData.failedReason ?? existing.failedReason,
             finishedOn,
             processedOn,
+            restarted: jobData.restarted ?? existing.restarted,
           };
           return updated;
         } else {
@@ -155,24 +163,38 @@ export function useJobsListener(options: UseJobsListenerOptions = {}) {
 
       if (event.event === "job.completed" && event.data) {
         if (jobData.jobType === "summarization") {
-          const notification = buildSummarizationCompletionNotification(
+          const notifications = buildSummarizationCompletionNotifications(
             jobData.result,
+            jobData.jobId,
           );
 
-          if (!notification) return;
+          if (notifications.length === 0) return;
 
-          addNotification(notification);
+          notifications.forEach(addNotification);
 
           // Show popup toast if enabled
           if (showPopups) {
-            toast.success(notification.title, {
-              description: notification.description,
-              action: notification.action && {
-                label: notification.action.label,
-                onClick: () => navigate(notification.action!.path),
+            const notification = notifications[0];
+            const isBatch = notifications.length > 1;
+            toast.success(
+              isBatch
+                ? `${notifications.length} summaries completed`
+                : notification.title,
+              {
+                description: isBatch
+                  ? "Open notifications to view each summary."
+                  : notification.description,
+                action: {
+                  label: isBatch
+                    ? "View notifications"
+                    : notification.action?.label || "View summary",
+                  onClick: () => navigate(
+                    isBatch ? "/summaries" : notification.action?.path || "/summaries",
+                  ),
+                },
+                duration: 10000,
               },
-              duration: 10000,
-            });
+            );
           }
         } else {
           const job = jobs.find((j) => j.id === jobData.jobId);

--- a/frontend/src/lib/jobDuration.ts
+++ b/frontend/src/lib/jobDuration.ts
@@ -1,0 +1,14 @@
+export function formatJobDuration(
+  start?: number,
+  end?: number,
+  now = Date.now(),
+): string {
+  if (!start) return "-";
+  const ms = (end ?? now) - start;
+  if (ms < 0) return "Restarted";
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+  const minutes = Math.floor(ms / 60000);
+  const seconds = Math.floor((ms % 60000) / 1000);
+  return `${minutes}m ${seconds}s`;
+}

--- a/frontend/src/lib/jobNotifications.test.ts
+++ b/frontend/src/lib/jobNotifications.test.ts
@@ -1,31 +1,65 @@
 import { describe, expect, it } from "vitest";
-import { buildSummarizationCompletionNotification } from "./jobNotifications";
+import { buildSummarizationCompletionNotifications } from "./jobNotifications";
 
-describe("buildSummarizationCompletionNotification", () => {
+describe("buildSummarizationCompletionNotifications", () => {
   it("links a single-object result to the summarized object", () => {
-    expect(buildSummarizationCompletionNotification({
+    expect(buildSummarizationCompletionNotifications({
       objectId: "object-123",
       title: "Planning call",
-    })).toEqual({
+    }, "job-456")).toEqual([{
       type: "success",
-      title: "Summarization completed",
-      description: '"Planning call"',
-      action: { label: "View", path: "/objects/object-123" },
-    });
+      title: "Planning call",
+      description: "Summary completed",
+      action: {
+        label: "View summary",
+        path: "/objects/object-123?summaryJobId=job-456",
+      },
+    }]);
   });
 
-  it("creates one notification for an automatic summary batch", () => {
-    expect(buildSummarizationCompletionNotification({ processed: 12 }))
-      .toEqual({
+  it("creates one direct notification per summary in an automatic batch", () => {
+    expect(buildSummarizationCompletionNotifications({
+      processed: 2,
+      summaries: [
+        { objectId: "object-1", title: "First topic" },
+        { objectId: "object-2", title: "Second topic" },
+      ],
+    }, "batch-job")).toEqual([
+      {
+        type: "success",
+        title: "First topic",
+        description: "Summary completed",
+        action: {
+          label: "View summary",
+          path: "/objects/object-1?summaryJobId=batch-job",
+        },
+      },
+      {
+        type: "success",
+        title: "Second topic",
+        description: "Summary completed",
+        action: {
+          label: "View summary",
+          path: "/objects/object-2?summaryJobId=batch-job",
+        },
+      },
+    ]);
+  });
+
+  it("keeps an aggregate fallback for older batch results", () => {
+    expect(
+      buildSummarizationCompletionNotifications({ processed: 12 }, "old-job"),
+    )
+      .toEqual([{
         type: "success",
         title: "12 summaries completed",
         description: "12 new conversation summaries are ready.",
         action: { label: "View summaries", path: "/summaries" },
-      });
+      }]);
   });
 
   it("does not notify when an automatic batch produced no summaries", () => {
-    expect(buildSummarizationCompletionNotification({ processed: 0 }))
-      .toBeNull();
+    expect(buildSummarizationCompletionNotifications({ processed: 0 }, "job"))
+      .toEqual([]);
   });
 });

--- a/frontend/src/lib/jobNotifications.ts
+++ b/frontend/src/lib/jobNotifications.ts
@@ -10,35 +10,69 @@ interface SummarizationResult {
   title?: string;
   end?: string;
   processed?: number;
+  summaries?: Array<{
+    objectId: string;
+    title?: string;
+  }>;
 }
 
-export function buildSummarizationCompletionNotification(
+function buildObjectNotification(
+  objectId: string,
+  title: string | undefined,
+  jobId: string,
+  end?: string,
+): PendingNotification {
+  const topic = title || "Conversation";
+  const date = end
+    ? new Date(end).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    })
+    : "";
+
+  return {
+    type: "success",
+    title: topic,
+    description: `Summary completed${date ? ` • ${date}` : ""}`,
+    action: {
+      label: "View summary",
+      path: `/objects/${objectId}?summaryJobId=${encodeURIComponent(jobId)}`,
+    },
+  };
+}
+
+export function buildSummarizationCompletionNotifications(
   result: SummarizationResult | undefined,
-): PendingNotification | null {
-  if (!result) return null;
+  jobId: string,
+): PendingNotification[] {
+  if (!result) return [];
 
   if (result.objectId) {
-    const title = result.title || "Conversation";
-    const date = result.end
-      ? new Date(result.end).toLocaleDateString(undefined, {
-        month: "short",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-      })
-      : "";
-
-    return {
-      type: "success",
-      title: "Summarization completed",
-      description: `"${title}"${date ? ` • ${date}` : ""}`,
-      action: { label: "View", path: `/objects/${result.objectId}` },
-    };
+    return [buildObjectNotification(
+      result.objectId,
+      result.title,
+      jobId,
+      result.end,
+    )];
   }
 
+  if (result.summaries?.length) {
+    return result.summaries.map((summary) =>
+      buildObjectNotification(
+        summary.objectId,
+        summary.title,
+        jobId,
+      )
+    );
+  }
+
+  // Backward-compatible fallback for jobs completed before per-item results
+  // were added to the worker response.
   if (typeof result.processed === "number" && result.processed > 0) {
     const count = result.processed;
-    return {
+    return [{
       type: "success",
       title: count === 1
         ? "1 summary completed"
@@ -47,8 +81,8 @@ export function buildSummarizationCompletionNotification(
         ? "A new conversation summary is ready."
         : `${count} new conversation summaries are ready.`,
       action: { label: "View summaries", path: "/summaries" },
-    };
+    }];
   }
 
-  return null;
+  return [];
 }

--- a/frontend/src/lib/jobs.test.ts
+++ b/frontend/src/lib/jobs.test.ts
@@ -1,0 +1,17 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { formatJobDuration } from "./jobDuration";
+
+describe("formatJobDuration", () => {
+  it("formats a completed job duration", () => {
+    expect(formatJobDuration(1_000, 62_500)).toBe("1m 1s");
+  });
+
+  it("uses the current time for an active job", () => {
+    expect(formatJobDuration(1_000, undefined, 3_500)).toBe("2.5s");
+  });
+
+  it("does not display negative duration from stale restart timestamps", () => {
+    expect(formatJobDuration(5_000, 4_000)).toBe("Restarted");
+  });
+});

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useParams, Link } from "react-router-dom";
+import type { ReactNode } from "react";
+import { useParams, Link, useNavigate } from "react-router-dom";
 import { format } from "date-fns";
 import { api } from "@/lib/api";
 import { useJobsListener } from "@/hooks/useJobsListener";
@@ -12,7 +13,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, Ban, FileText, Clock, Hash, MessageSquare, ExternalLink, Users, Layers, AlertTriangle, Volume2, Tag, BarChart3, type LucideIcon } from "lucide-react";
+import { ArrowLeft, Ban, FileText, Clock, Hash, MessageSquare, ExternalLink, Users, Layers, AlertTriangle, Volume2, Tag, BarChart3, Play, RefreshCw, type LucideIcon } from "lucide-react";
 import { ObjectAudioPlayer } from "@/components/ObjectAudioPlayer";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { JobInfo, JobLogEntry, JobAccessLogEntry } from "@/types/jobs";
@@ -89,7 +90,7 @@ const formatValue = (value: any): string => {
     return String(value);
 };
 
-function MetricCell({ icon: Icon, label, value }: { icon: LucideIcon; label: string; value: string | number | boolean | null | undefined }) {
+function MetricCell({ icon: Icon, label, value }: { icon: LucideIcon; label: string; value: ReactNode }) {
     return (
         <div className="flex items-center gap-2">
             <Icon className="h-4 w-4 text-muted-foreground" />
@@ -124,12 +125,13 @@ function FieldDisplay({ fields }: { fields: Array<[string, any]> }) {
 
 export default function JobDetailPage() {
     const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
     const { getJobById, isLoading: isListenerLoading } = useJobsListener();
     const queryClient = useQueryClient();
 
     const cachedJob = id ? getJobById(id) : null;
 
-    const { data: fetchedJob, isLoading: isFetching, refetch } = useQuery({
+    const { data: fetchedJob, isLoading: isFetching, isFetching: isRefreshing, refetch } = useQuery({
         queryKey: ["job", id],
         queryFn: async () => {
             if (!id) {
@@ -141,10 +143,18 @@ export default function JobDetailPage() {
             });
             return response as JobInfo;
         },
-        enabled: !!id && !cachedJob,
+        enabled: !!id,
+        refetchInterval: (query) => {
+            const state = (query.state.data as JobInfo | undefined)?.state;
+            return state && ["active", "waiting", "delayed"].includes(state)
+                ? 3_000
+                : false;
+        },
     });
 
-    const job = cachedJob || fetchedJob;
+    // Prefer the detail endpoint because it also checks BullMQ and refreshes
+    // when list websocket events are missed.
+    const job = fetchedJob || cachedJob;
     const isTranscriptionJob = job?.type === "transcription";
     const isLoading = (isListenerLoading && !cachedJob) || (isFetching && !cachedJob);
 
@@ -278,12 +288,36 @@ export default function JobDetailPage() {
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["job", id] });
             queryClient.invalidateQueries({ queryKey: ["jobs", "all"] });
+            refetch();
+        },
+    });
+
+    const rerunJobMutation = useMutation({
+        mutationFn: async () => {
+            if (!job) throw new Error("Job is not loaded");
+            return await api.callResource("jobs", {
+                action: "enqueue",
+                data: job.data,
+                trigger: {
+                    type: "manual",
+                    reason: `rerun:${job.id}`,
+                },
+            }) as { jobId: string };
+        },
+        onSuccess: (result) => {
+            queryClient.invalidateQueries({ queryKey: ["jobs"] });
+            navigate(`/jobs/${result.jobId}`);
         },
     });
 
     const handleCancel = async () => {
-        if (!confirm("Are you sure you want to cancel this job?")) return;
+        if (!confirm("Cancel this job? An active worker process will be stopped.")) return;
         cancelJobMutation.mutate();
+    };
+
+    const handleRerun = () => {
+        if (!confirm("Run a new job with the same input?")) return;
+        rerunJobMutation.mutate();
     };
     const getStatusColor = (status: string) => {
         switch (status) {
@@ -305,6 +339,7 @@ export default function JobDetailPage() {
     const formatDuration = (start?: number, end?: number) => {
         if (!start || !end) return "-";
         const ms = end - start;
+        if (ms < 0) return "-";
         if (ms < 1000) return `${ms}ms`;
         if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
         return `${(ms / 60000).toFixed(1)}m`;
@@ -353,17 +388,39 @@ export default function JobDetailPage() {
                         </p>
                     </div>
                 </div>
-                {["active", "waiting", "delayed"].includes(job.state) && (
+                <div className="flex items-center gap-2">
                     <Button
-                        variant="destructive"
+                        variant="outline"
                         size="sm"
-                        onClick={handleCancel}
-                        disabled={cancelJobMutation.isPending}
+                        onClick={() => refetch()}
+                        disabled={isRefreshing}
                     >
-                        <Ban className="h-4 w-4 mr-2" />
-                        Cancel Job
+                        <RefreshCw className={`h-4 w-4 mr-2 ${isRefreshing ? "animate-spin" : ""}`} />
+                        Refresh state
                     </Button>
-                )}
+                    {!["active", "waiting", "delayed"].includes(job.state) && (
+                        <Button
+                            variant="default"
+                            size="sm"
+                            onClick={handleRerun}
+                            disabled={rerunJobMutation.isPending}
+                        >
+                            <Play className="h-4 w-4 mr-2" />
+                            Run again
+                        </Button>
+                    )}
+                    {["active", "waiting", "delayed"].includes(job.state) && (
+                        <Button
+                            variant="destructive"
+                            size="sm"
+                            onClick={handleCancel}
+                            disabled={cancelJobMutation.isPending}
+                        >
+                            <Ban className="h-4 w-4 mr-2" />
+                            Cancel Job
+                        </Button>
+                    )}
+                </div>
             </div>
 
             <div className="grid gap-6 md:grid-cols-2">
@@ -377,6 +434,19 @@ export default function JobDetailPage() {
                             <Badge className={getStatusColor(job.state)}>
                                 {job.state}
                             </Badge>
+                        </div>
+                        <div>
+                            <div className="text-sm text-muted-foreground mb-1">Queue state</div>
+                            <div className="flex items-center gap-2">
+                                <Badge variant="outline">
+                                    {job.queuePresent ? (job.queueState || "unknown") : "not present"}
+                                </Badge>
+                                {job.state === "active" && job.queueState !== "active" && (
+                                    <span className="text-xs text-amber-500">
+                                        Database and queue states do not match
+                                    </span>
+                                )}
+                            </div>
                         </div>
                         <div>
                             <div className="text-sm text-muted-foreground mb-1">Type</div>
@@ -465,6 +535,16 @@ export default function JobDetailPage() {
                                 </div>
                                 <div className="text-sm">
                                     {format(new Date(job.finishedOn), "PPpp")}
+                                </div>
+                            </div>
+                        )}
+                        {job.updatedOn && (
+                            <div>
+                                <div className="text-sm text-muted-foreground mb-1">
+                                    Last state update
+                                </div>
+                                <div className="text-sm">
+                                    {format(new Date(job.updatedOn), "PPpp")}
                                 </div>
                             </div>
                         )}

--- a/frontend/src/pages/JobsPage.tsx
+++ b/frontend/src/pages/JobsPage.tsx
@@ -17,7 +17,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { RefreshCw, Trash2, Play, Search, ChevronDown, ArrowUpDown, ArrowUp, ArrowDown, PlayCircle, PauseCircle, Activity, Clock, AlertCircle, CheckCircle, X, Copy, Check } from "lucide-react";
+import { RefreshCw, Trash2, Play, Search, ChevronDown, ArrowUpDown, ArrowUp, ArrowDown, PlayCircle, PauseCircle, Activity, Clock, AlertCircle, CheckCircle, X, Copy, Check, RotateCcw } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   DropdownMenu,
@@ -32,6 +32,7 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import type { JobInfo } from "@/types/jobs";
 import { parseJobError } from "@/lib/jobs";
+import { formatJobDuration } from "@/lib/jobDuration";
 
 type WorkerStatus = {
   workers: Record<string, { paused: boolean }>;
@@ -321,7 +322,15 @@ function JobProgressCell({ job }: { job: JobInfo }) {
   if (job.type === "conversation_extractor") {
     if (isCompleted) {
       if ((result.conversationsCreated ?? 0) === 0 && (result.chunksProcessed ?? 0) === 0) {
-        return <Badge variant="secondary" className="bg-amber-500/10 text-amber-500 text-xs">Empty</Badge>;
+        return (
+          <Badge
+            variant="secondary"
+            className="bg-muted text-muted-foreground text-xs"
+            title="No conversation chunks were ready to process"
+          >
+            Idling
+          </Badge>
+        );
       }
       return (
         <div className="space-y-1">
@@ -665,6 +674,8 @@ export default function JobsPage() {
           type: string;
           totalRuns: number;
           active: number;
+          staleActive: number;
+          staleClaims: number;
           waiting: number;
           delayed: number;
           completed: number;
@@ -750,6 +761,36 @@ export default function JobsPage() {
     onError: (error) => {
       console.error("Failed to clear worker queue:", error);
       alert("Failed to clear worker queue");
+    },
+  });
+
+  const resetWorkerMutation = useMutation({
+    mutationFn: async (workerType: string) => {
+      return await api.callResource("jobs", {
+        action: "reset_worker",
+        workerType,
+        restart: true,
+      }) as {
+        workerType: string;
+        cancelledCount: number;
+        terminatedCount: number;
+        claimsCleared: number;
+        restartedJobId?: string;
+      };
+    },
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["jobs"] });
+      queryClient.invalidateQueries({ queryKey: ["job-stats"] });
+      refetchWorkerStatus();
+      alert(
+        `Reset ${result.workerType}: cancelled ${result.cancelledCount} job(s), ` +
+          `stopped ${result.terminatedCount} active process(es), cleared ` +
+          `${result.claimsCleared} claim(s), and started one fresh job.`,
+      );
+    },
+    onError: (error) => {
+      console.error("Failed to reset worker:", error);
+      alert("Failed to reset worker");
     },
   });
 
@@ -903,6 +944,25 @@ export default function JobsPage() {
       )
     ) {
       clearQueueMutation.mutate(workerType);
+    }
+  };
+
+  const handleResetWorker = (
+    workerType: string,
+    active: number,
+    waiting: number,
+    delayed: number,
+    staleClaims: number,
+  ) => {
+    if (
+      confirm(
+        `Reset and restart ${workerType}?\n\n` +
+          `This will stop ${active} active job(s), cancel ${waiting + delayed} queued job(s), ` +
+          `and clear ${staleClaims} stale claim(s).\n\n` +
+          "Exactly one fresh job will then be started.",
+      )
+    ) {
+      resetWorkerMutation.mutate(workerType);
     }
   };
 
@@ -1145,21 +1205,10 @@ export default function JobsPage() {
     return () => clearInterval(interval);
   }, []);
 
-  const formatDuration = (start?: number, end?: number) => {
-    if (!start) return "-";
-    const endTime = end || currentTime;
-    const ms = endTime - start;
-    if (ms < 1000) return `${ms}ms`;
-    if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
-    const minutes = Math.floor(ms / 60000);
-    const seconds = Math.floor((ms % 60000) / 1000);
-    return `${minutes}m ${seconds}s`;
-  };
-
   const handleCancelAll = async () => {
     if (
       !confirm(
-        "Are you sure you want to cancel all running jobs and clear queues? This action cannot be undone."
+        "Clear all queued jobs? Active jobs will keep running so their locks and saved results remain consistent."
       )
     ) {
       return;
@@ -1252,7 +1301,7 @@ export default function JobsPage() {
             onClick={handleCancelAll}
           >
             <Trash2 className="h-4 w-4 mr-2" />
-            Cancel All
+            Clear Queued
           </Button>
           {import.meta.env.DEV && (
             <Button
@@ -1302,6 +1351,7 @@ export default function JobsPage() {
                   <TableHead>Worker</TableHead>
                   <TableHead className="text-center w-[50px]">Active</TableHead>
                   <TableHead className="text-center w-[50px]">Queue</TableHead>
+                  <TableHead className="text-center w-[50px]">Stale</TableHead>
                   <TableHead className="text-center w-[50px]">Err</TableHead>
                   <TableHead className="text-center w-[60px]">Runs</TableHead>
                   <TableHead className="text-center w-[70px]">Success</TableHead>
@@ -1363,6 +1413,29 @@ export default function JobsPage() {
                             </TooltipTrigger>
                             <TooltipContent>Clear {worker.type} queue</TooltipContent>
                           </Tooltip>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-7 w-7"
+                                disabled={resetWorkerMutation.isPending}
+                                onClick={() =>
+                                  handleResetWorker(
+                                    worker.type,
+                                    stats?.active ?? 0,
+                                    stats?.waiting ?? 0,
+                                    stats?.delayed ?? 0,
+                                    stats?.staleClaims ?? 0,
+                                  )}
+                              >
+                                <RotateCcw className="h-3.5 w-3.5 text-amber-500" />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              Reset state and start one fresh {worker.type} job
+                            </TooltipContent>
+                          </Tooltip>
                         </div>
                       </TableCell>
                       <TableCell className="py-1">
@@ -1382,6 +1455,22 @@ export default function JobsPage() {
                       <TableCell className="text-center py-1">
                         {(stats?.waiting ?? 0) > 0 ? (
                           <span className="text-yellow-500 text-sm font-medium">{stats?.waiting}</span>
+                        ) : (
+                          <span className="text-muted-foreground/50">-</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-center py-1">
+                        {((stats?.staleActive ?? 0) + (stats?.staleClaims ?? 0)) > 0 ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="text-amber-500 text-sm font-medium cursor-help">
+                                {(stats?.staleActive ?? 0) + (stats?.staleClaims ?? 0)}
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              {stats?.staleActive ?? 0} stale active job(s), {stats?.staleClaims ?? 0} stale claim(s)
+                            </TooltipContent>
+                          </Tooltip>
                         ) : (
                           <span className="text-muted-foreground/50">-</span>
                         )}
@@ -1692,8 +1781,28 @@ export default function JobsPage() {
                         ? format(new Date(job.timestamp), "MMM d, HH:mm:ss")
                         : "-"}
                     </TableCell>
-                    <TableCell className="text-sm">
-                      {formatDuration(job.processedOn, job.finishedOn)}
+                    <TableCell
+                      className={job.restarted ||
+                          (job.finishedOn && job.processedOn &&
+                            job.finishedOn < job.processedOn)
+                        ? "text-sm text-amber-500"
+                        : "text-sm"}
+                      title={job.finishedOn && job.processedOn &&
+                          job.finishedOn < job.processedOn
+                        ? "This job was restarted and still has stale timestamps from an earlier attempt"
+                        : job.restarted
+                        ? "This job has been restarted; duration is for the latest attempt"
+                        : undefined}
+                    >
+                      {formatJobDuration(
+                        job.processedOn,
+                        job.finishedOn,
+                        currentTime,
+                      )}
+                      {job.restarted && !(job.finishedOn && job.processedOn &&
+                          job.finishedOn < job.processedOn) && (
+                        <span className="ml-1 text-xs">(retry)</span>
+                      )}
                     </TableCell>
                     <TableCell>
                       <JobProgressCell job={job} />
@@ -1702,6 +1811,7 @@ export default function JobsPage() {
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <button
+                            type="button"
                             onClick={() => {
                               navigator.clipboard.writeText(job.id);
                               setCopiedId(job.id);

--- a/frontend/src/pages/ObjectDetailPage.tsx
+++ b/frontend/src/pages/ObjectDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import type { Object, ObjectFormData } from "@/types/objects";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -150,6 +150,8 @@ function EditableTitle({
 
 const ObjectDetailPage = () => {
   const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
+  const summaryJobId = searchParams.get("summaryJobId");
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   // Use React Query hooks
@@ -490,6 +492,7 @@ const ObjectDetailPage = () => {
           {/* Summary - with model selector, generate button, and history navigation */}
           <SummarySection
             object={pendingChanges.summaries ? { ...object, summaries: pendingChanges.summaries } : object}
+            summaryJobId={summaryJobId}
             onSummaryClick={setSelectedSummary}
             onStarSummary={handleStarSummary}
           />

--- a/frontend/src/pages/SummaryHistoryPage.tsx
+++ b/frontend/src/pages/SummaryHistoryPage.tsx
@@ -89,8 +89,24 @@ function SummaryHistoryCard({ entry }: { entry: SummaryHistoryEntry }) {
                 <CheckCircle2 className="h-3 w-3" />
                 Summary saved
               </Badge>
-              {entry.jobState && entry.jobState !== "completed" && (
-                <Badge variant="secondary">Job record: {entry.jobState}</Badge>
+              {entry.jobState === "failed" && (
+                <Badge variant="destructive">
+                  Batch job failed after this summary was saved
+                </Badge>
+              )}
+              {entry.jobState === "cancelled" && (
+                <Badge variant="secondary">
+                  Batch job was cancelled after this summary was saved
+                </Badge>
+              )}
+              {entry.jobState && ![
+                  "completed",
+                  "failed",
+                  "cancelled",
+                ].includes(entry.jobState) && (
+                <Badge variant="secondary">
+                  Batch job record: {entry.jobState}
+                </Badge>
               )}
               {entry.fallbackUsed && (
                 <Badge variant="destructive">Fallback used</Badge>

--- a/frontend/src/pages/TranscriptPage.tsx
+++ b/frontend/src/pages/TranscriptPage.tsx
@@ -59,6 +59,14 @@ interface DiarizationDoc {
   };
 }
 
+interface ConversationDoc {
+  _id: unknown;
+  timeRanges?: Array<{
+    start: Date | string;
+    end?: Date | string;
+  }>;
+}
+
 function parseDateParam(value: string | null): Date | null {
   if (!value) return null;
   // Support ISO strings and millis since epoch
@@ -111,6 +119,9 @@ const TranscriptPage = () => {
   const [searchError, setSearchError] = useState<string | null>(null);
   const [searchSegments, setSearchSegments] = useState<RenderSegment[]>([]);
   const [lastSearchedQ, setLastSearchedQ] = useState<string>(initialQ);
+  const [openingConversationKey, setOpeningConversationKey] = useState<
+    string | null
+  >(null);
 
   const [formStartDate, setFormStartDate] = useState<Date | undefined>(
     undefined,
@@ -275,6 +286,7 @@ const TranscriptPage = () => {
         $project: {
           start: 1,
           end: 1,
+          original: 1,
           segments: 1,
           score: { $meta: "textScore" },
         },
@@ -385,6 +397,93 @@ const TranscriptPage = () => {
   function handlePlayFromSegment(segmentTime: Date) {
     resetDate(segmentTime);
     setIsPlaying(true);
+  }
+
+  async function handleOpenFullConversation(seg: RenderSegment) {
+    const key = `${seg.time.getTime()}-${seg.endTime.getTime()}`;
+    setOpeningConversationKey(key);
+    setSearchError(null);
+
+    try {
+      const conversations = await callResource("mongo", {
+        action: "find",
+        collection: "objects",
+        query: {
+          isConversation: true,
+          timeRanges: {
+            $elemMatch: {
+              start: { $lte: seg.time },
+              end: { $gte: seg.endTime },
+            },
+          },
+        },
+        options: { limit: 50 },
+      }) as ConversationDoc[];
+
+      const containingRanges = conversations.flatMap((conversation) =>
+        (conversation.timeRanges ?? []).flatMap((range) => {
+          if (!range.end) return [];
+          const start = new Date(range.start);
+          const end = new Date(range.end);
+          if (
+            Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) ||
+            start > seg.time || end < seg.endTime
+          ) {
+            return [];
+          }
+          return [{ start, end }];
+        })
+      ).sort((a, b) =>
+        (a.end.getTime() - a.start.getTime()) -
+        (b.end.getTime() - b.start.getTime())
+      );
+
+      let range = containingRanges[0];
+
+      // Older recordings may not have an extracted Conversation object yet.
+      // In that case, use all transcription chunks from the same source audio.
+      if (!range && seg.original_id) {
+        const [firstDocs, lastDocs] = await Promise.all([
+          callResource("mongo", {
+            action: "find",
+            collection: "transcriptions",
+            query: { original: seg.original_id },
+            options: { sort: { start: 1 }, limit: 1 },
+          }) as Promise<TranscriptionDoc[]>,
+          callResource("mongo", {
+            action: "find",
+            collection: "transcriptions",
+            query: { original: seg.original_id },
+            options: { sort: { end: -1 }, limit: 1 },
+          }) as Promise<TranscriptionDoc[]>,
+        ]);
+
+        if (firstDocs[0] && lastDocs[0]) {
+          range = {
+            start: new Date(firstDocs[0].start),
+            end: new Date(lastDocs[0].end),
+          };
+        }
+      }
+
+      if (!range) {
+        throw new Error("Could not find the full conversation for this phrase");
+      }
+
+      setQ("");
+      setLastSearchedQ("");
+      setSearchSegments([]);
+      setSegments([]);
+      navigate(
+        `?start=${range.start.getTime()}&end=${range.end.getTime()}`,
+      );
+    } catch (err) {
+      setSearchError(
+        err instanceof Error ? err.message : "Failed to open conversation",
+      );
+    } finally {
+      setOpeningConversationKey(null);
+    }
   }
 
   useEffect(() => {
@@ -672,25 +771,40 @@ const TranscriptPage = () => {
                                 {formatTimeRangeDuration(seg.time, seg.endTime)}
                               </span>
                               {lastSearchedQ && (
-                                <button
-                                  type="button"
-                                  className="ml-2 text-blue-600 hover:text-blue-800 hover:underline"
-                                  onClick={() => {
-                                    const center = seg.time.getTime();
-                                    const offset = 5 * 60 * 1000;
-                                    setQ("");
-                                    setLastSearchedQ("");
-                                    setSearchSegments([]);
-                                    setSegments([]);
-                                    navigate(
-                                      `?start=${center - offset}&end=${
-                                        center + offset
-                                      }`,
-                                    );
-                                  }}
-                                >
-                                  Context
-                                </button>
+                                <>
+                                  <button
+                                    type="button"
+                                    className="ml-2 text-blue-600 hover:text-blue-800 hover:underline"
+                                    onClick={() => {
+                                      const center = seg.time.getTime();
+                                      const offset = 5 * 60 * 1000;
+                                      setQ("");
+                                      setLastSearchedQ("");
+                                      setSearchSegments([]);
+                                      setSegments([]);
+                                      navigate(
+                                        `?start=${center - offset}&end=${
+                                          center + offset
+                                        }`,
+                                      );
+                                    }}
+                                  >
+                                    Context
+                                  </button>
+                                  <button
+                                    type="button"
+                                    className="ml-2 text-blue-600 hover:text-blue-800 hover:underline disabled:cursor-wait disabled:opacity-50"
+                                    disabled={openingConversationKey ===
+                                      `${seg.time.getTime()}-${seg.endTime.getTime()}`}
+                                    onClick={() =>
+                                      handleOpenFullConversation(seg)}
+                                  >
+                                    {openingConversationKey ===
+                                        `${seg.time.getTime()}-${seg.endTime.getTime()}`
+                                      ? "Opening…"
+                                      : "Full conversation"}
+                                  </button>
+                                </>
                               )}
                             </div>
                             {identifiedSpeakers.map((diarization) => (

--- a/frontend/src/pages/TranscriptPage.tsx
+++ b/frontend/src/pages/TranscriptPage.tsx
@@ -6,7 +6,6 @@ import { formatTime, formatTimeRangeDuration } from "@/lib/formatTime";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { DateTimePicker } from "@/components/ui/datetime-picker";
 import {
   Tooltip,
   TooltipContent,
@@ -61,10 +60,18 @@ interface DiarizationDoc {
 
 interface ConversationDoc {
   _id: unknown;
+  name?: string;
   timeRanges?: Array<{
     start: Date | string;
     end?: Date | string;
   }>;
+}
+
+interface ResolvedConversation {
+  id: string;
+  name?: string;
+  start: Date;
+  end: Date;
 }
 
 function parseDateParam(value: string | null): Date | null {
@@ -77,6 +84,82 @@ function parseDateParam(value: string | null): Date | null {
   }
   const d = new Date(value);
   return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function toDateInputValue(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function toTimeInputValue(date: Date): string {
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${hours}:${minutes}`;
+}
+
+function replaceLocalDate(current: Date, value: string): Date | null {
+  const [year, month, day] = value.split("-").map(Number);
+  if (!year || !month || !day) return null;
+  const next = new Date(current);
+  next.setFullYear(year, month - 1, day);
+  return Number.isNaN(next.getTime()) ? null : next;
+}
+
+function replaceLocalTime(current: Date, value: string): Date | null {
+  const [hours, minutes] = value.split(":").map(Number);
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return null;
+  const next = new Date(current);
+  next.setHours(hours, minutes, 0, 0);
+  return Number.isNaN(next.getTime()) ? null : next;
+}
+
+function TranscriptDateTimeInput({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value?: Date;
+  onChange: (date: Date) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1 sm:flex-row sm:items-end">
+      <label className="grid gap-1 text-sm font-medium">
+        <span>{label} date</span>
+        <Input
+          type="date"
+          aria-label={`${label} date`}
+          value={value ? toDateInputValue(value) : ""}
+          onChange={(event) => {
+            const next = replaceLocalDate(
+              value ?? new Date(),
+              event.target.value,
+            );
+            if (next) onChange(next);
+          }}
+          className="w-full sm:w-[170px]"
+        />
+      </label>
+      <label className="grid gap-1 text-sm font-medium">
+        <span>Time</span>
+        <Input
+          type="time"
+          aria-label={`${label} time`}
+          value={value ? toTimeInputValue(value) : ""}
+          onChange={(event) => {
+            const next = replaceLocalTime(
+              value ?? new Date(),
+              event.target.value,
+            );
+            if (next) onChange(next);
+          }}
+          className="w-full sm:w-[130px]"
+        />
+      </label>
+    </div>
+  );
 }
 
 const TranscriptPage = () => {
@@ -216,14 +299,13 @@ const TranscriptPage = () => {
     return rendered;
   }
 
-  async function handleApplyRange() {
-    if (!formStartDate || !formEndDate) return;
-    const startNorm = formStartDate.getTime() > formEndDate.getTime()
-      ? formEndDate
-      : formStartDate;
-    const endNorm = formStartDate.getTime() > formEndDate.getTime()
-      ? formStartDate
-      : formEndDate;
+  async function applyRange(rangeStart: Date, rangeEnd: Date) {
+    const startNorm = rangeStart.getTime() > rangeEnd.getTime()
+      ? rangeEnd
+      : rangeStart;
+    const endNorm = rangeStart.getTime() > rangeEnd.getTime()
+      ? rangeStart
+      : rangeEnd;
     setLoading(true);
     setError(null);
     setSearchError(null);
@@ -267,6 +349,36 @@ const TranscriptPage = () => {
     }
   }
 
+  async function handleApplyRange() {
+    if (!formStartDate || !formEndDate) return;
+    await applyRange(formStartDate, formEndDate);
+  }
+
+  function applyQuickRange(
+    preset: "today" | "yesterday" | "week" | "month",
+  ) {
+    const now = new Date();
+    const start = new Date(now);
+    let end = new Date(now);
+
+    if (preset === "today") {
+      start.setHours(0, 0, 0, 0);
+    } else if (preset === "yesterday") {
+      start.setDate(start.getDate() - 1);
+      start.setHours(0, 0, 0, 0);
+      end = new Date(start);
+      end.setDate(end.getDate() + 1);
+    } else if (preset === "week") {
+      start.setDate(start.getDate() - 7);
+    } else {
+      start.setDate(start.getDate() - 30);
+    }
+
+    setFormStartDate(start);
+    setFormEndDate(end);
+    void applyRange(start, end);
+  }
+
   async function fetchSearch(
     rangeStart: Date,
     rangeEnd: Date,
@@ -294,11 +406,30 @@ const TranscriptPage = () => {
       { $limit: 200 },
     ];
 
-    const docs: TranscriptionDoc[] = await callResource("mongo", {
+    let docs: TranscriptionDoc[] = await callResource("mongo", {
       action: "aggregate",
       collection: "transcriptions",
       pipeline,
     });
+
+    // MongoDB text indexes may omit pure numbers and some short/stemmed words.
+    // Fall back to a literal case-insensitive match so saved phrase links such
+    // as `q=300` still work as users expect.
+    if (docs.length === 0) {
+      docs = await callResource("mongo", {
+        action: "find",
+        collection: "transcriptions",
+        query: {
+          start: { $lt: rangeEnd },
+          end: { $gt: rangeStart },
+          text: {
+            $regex: escapeRegex(query.trim()),
+            $options: "i",
+          },
+        },
+        options: { sort: { start: 1 }, limit: 200 },
+      }) as TranscriptionDoc[];
+    }
 
     const loweredWords = query
       .split(/\s+/)
@@ -391,7 +522,7 @@ const TranscriptPage = () => {
     const fifteenMinutesAgo = new Date(now.getTime() - 15 * 60 * 1000);
     setFormStartDate(fifteenMinutesAgo);
     setFormEndDate(now);
-    handleApplyRange();
+    void applyRange(fifteenMinutesAgo, now);
   }
 
   function handlePlayFromSegment(segmentTime: Date) {
@@ -399,46 +530,78 @@ const TranscriptPage = () => {
     setIsPlaying(true);
   }
 
-  async function handleOpenFullConversation(seg: RenderSegment) {
-    const key = `${seg.time.getTime()}-${seg.endTime.getTime()}`;
+  async function resolveConversation(
+    seg: RenderSegment,
+  ): Promise<ResolvedConversation | null> {
+    const conversations = await callResource("mongo", {
+      action: "find",
+      collection: "objects",
+      query: {
+        isConversation: true,
+        timeRanges: {
+          $elemMatch: {
+            start: { $lte: seg.time },
+            end: { $gte: seg.endTime },
+          },
+        },
+      },
+      options: { limit: 50 },
+    }) as ConversationDoc[];
+
+    const containingRanges = conversations.flatMap((conversation) =>
+      (conversation.timeRanges ?? []).flatMap((range) => {
+        if (!range.end) return [];
+        const start = new Date(range.start);
+        const end = new Date(range.end);
+        if (
+          Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) ||
+          start > seg.time || end < seg.endTime
+        ) {
+          return [];
+        }
+        const id = normalizeObjectId(conversation._id) ??
+          String(conversation._id);
+        return [{ id, name: conversation.name, start, end }];
+      })
+    ).sort((a, b) =>
+      (a.end.getTime() - a.start.getTime()) -
+      (b.end.getTime() - b.start.getTime())
+    );
+
+    return containingRanges[0] ?? null;
+  }
+
+  async function handleOpenConversationObject(seg: RenderSegment) {
+    const key = `summary-${seg.time.getTime()}-${seg.endTime.getTime()}`;
     setOpeningConversationKey(key);
     setSearchError(null);
 
     try {
-      const conversations = await callResource("mongo", {
-        action: "find",
-        collection: "objects",
-        query: {
-          isConversation: true,
-          timeRanges: {
-            $elemMatch: {
-              start: { $lte: seg.time },
-              end: { $gte: seg.endTime },
-            },
-          },
-        },
-        options: { limit: 50 },
-      }) as ConversationDoc[];
-
-      const containingRanges = conversations.flatMap((conversation) =>
-        (conversation.timeRanges ?? []).flatMap((range) => {
-          if (!range.end) return [];
-          const start = new Date(range.start);
-          const end = new Date(range.end);
-          if (
-            Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) ||
-            start > seg.time || end < seg.endTime
-          ) {
-            return [];
-          }
-          return [{ start, end }];
-        })
-      ).sort((a, b) =>
-        (a.end.getTime() - a.start.getTime()) -
-        (b.end.getTime() - b.start.getTime())
+      const conversation = await resolveConversation(seg);
+      if (!conversation) {
+        throw new Error("No Conversation object exists for this phrase yet");
+      }
+      navigate(`/objects/${conversation.id}`);
+    } catch (err) {
+      setSearchError(
+        err instanceof Error ? err.message : "Failed to open conversation",
       );
+    } finally {
+      setOpeningConversationKey(null);
+    }
+  }
 
-      let range = containingRanges[0];
+  async function handleOpenFullConversation(seg: RenderSegment) {
+    const key = `full-${seg.time.getTime()}-${seg.endTime.getTime()}`;
+    setOpeningConversationKey(key);
+    setSearchError(null);
+
+    try {
+      const conversation = await resolveConversation(seg);
+
+      let range = conversation
+        ? { start: conversation.start, end: conversation.end }
+        : undefined;
 
       // Older recordings may not have an extracted Conversation object yet.
       // In that case, use all transcription chunks from the same source audio.
@@ -501,12 +664,18 @@ const TranscriptPage = () => {
           e = tmp;
           updateRange(s, e);
         }
-        const [rendered, diarizationsData] = await Promise.all([
-          fetchSegmentsRange(s, e),
-          fetchDiarizationsRange(s, e),
-        ]);
+        const query = initialQ.trim();
+        const [rendered, diarizationsData, searchedSegments] = await Promise
+          .all([
+            fetchSegmentsRange(s, e),
+            fetchDiarizationsRange(s, e),
+            query ? fetchSearch(s, e, query) : Promise.resolve([]),
+          ]);
         setSegments(rendered);
         setDiarizations(diarizationsData);
+        setSearchSegments(searchedSegments);
+        setLastSearchedQ(query);
+        setQ(query);
         setDisplayStart(s);
         setDisplayEnd(e);
         setFormStartDate(s);
@@ -527,7 +696,7 @@ const TranscriptPage = () => {
     }
 
     initialFetch();
-  }, [startDate, endDate, startParam, endParam]);
+  }, [startDate, endDate, startParam, endParam, initialQ]);
 
   if (loading) {
     return (
@@ -558,34 +727,70 @@ const TranscriptPage = () => {
       </div>
 
       <form
-        className="space-y-4 flex flex-col gap-2"
+        className="space-y-4 rounded-lg border bg-card p-4"
         onSubmit={(e) => {
           e.preventDefault();
           handleApplyRange();
         }}
       >
-        <div className="flex gap-2">
-          <label htmlFor="start">Start</label>
-
-          <DateTimePicker
+        <div className="grid gap-4 lg:grid-cols-2">
+          <TranscriptDateTimeInput
+            label="Start"
             value={formStartDate}
-            onChange={(date) => date && setFormStartDate(date)}
-            placeholder="Start"
+            onChange={setFormStartDate}
           />
-        </div>
-        <div className="flex gap-2">
-          <label htmlFor="end">End</label>
-          <DateTimePicker
+          <TranscriptDateTimeInput
+            label="End"
             value={formEndDate}
-            onChange={(date) => date && setFormEndDate(date)}
-            placeholder="End"
+            onChange={setFormEndDate}
           />
         </div>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="mr-1 text-sm text-muted-foreground">
+            Quick range
+          </span>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => applyQuickRange("today")}
+            disabled={loading || searching}
+          >
+            Today
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => applyQuickRange("yesterday")}
+            disabled={loading || searching}
+          >
+            Yesterday
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => applyQuickRange("week")}
+            disabled={loading || searching}
+          >
+            Last 7 days
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => applyQuickRange("month")}
+            disabled={loading || searching}
+          >
+            Last 30 days
+          </Button>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row">
           <Input
             value={q}
             onChange={(e) => setQ(e.target.value)}
-            placeholder="Search"
+            placeholder="Search transcript…"
             className="flex-1"
           />
           <Button
@@ -795,14 +1000,27 @@ const TranscriptPage = () => {
                                     type="button"
                                     className="ml-2 text-blue-600 hover:text-blue-800 hover:underline disabled:cursor-wait disabled:opacity-50"
                                     disabled={openingConversationKey ===
-                                      `${seg.time.getTime()}-${seg.endTime.getTime()}`}
+                                      `full-${seg.time.getTime()}-${seg.endTime.getTime()}`}
                                     onClick={() =>
                                       handleOpenFullConversation(seg)}
                                   >
                                     {openingConversationKey ===
-                                        `${seg.time.getTime()}-${seg.endTime.getTime()}`
+                                        `full-${seg.time.getTime()}-${seg.endTime.getTime()}`
                                       ? "Opening…"
                                       : "Full conversation"}
+                                  </button>
+                                  <button
+                                    type="button"
+                                    className="ml-2 font-medium text-blue-600 hover:text-blue-800 hover:underline disabled:cursor-wait disabled:opacity-50"
+                                    disabled={openingConversationKey ===
+                                      `summary-${seg.time.getTime()}-${seg.endTime.getTime()}`}
+                                    onClick={() =>
+                                      handleOpenConversationObject(seg)}
+                                  >
+                                    {openingConversationKey ===
+                                        `summary-${seg.time.getTime()}-${seg.endTime.getTime()}`
+                                      ? "Opening…"
+                                      : "Conversation & summary"}
                                   </button>
                                 </>
                               )}

--- a/frontend/src/types/jobs.ts
+++ b/frontend/src/types/jobs.ts
@@ -16,6 +16,10 @@ export type JobInfo = {
   processedOn?: number;
   failedReason?: string;
   attemptsMade?: number;
+  restarted?: boolean;
+  updatedOn?: number;
+  queueState?: string | null;
+  queuePresent?: boolean;
 };
 
 export interface JobLogEntry {


### PR DESCRIPTION
## Summary

- make job cancellation, worker reset, reruns, and queue/database reconciliation safer and visible in the UI
- emit one direct notification per completed summary and open the exact summary from its notification
- add full-conversation navigation from transcript search results

## Why

- clearing or restarting workers could leave active processes, stale claims, and mismatched queue/database states
- batch summarization notifications did not identify or link to each saved summary
- transcript search only exposed a narrow context window instead of the containing conversation

## Validation

- `deno check` passed for the changed backend job, worker, and summarization modules
- backend queue/reset authorization tests: 4 passed
- frontend focused tests: 7 passed (`jobNotifications.test.ts`, `jobs.test.ts`)
- `git diff --check` passed before committing

## Known baseline / environment blockers

- frontend project typecheck still reports 26 pre-existing errors in unchanged files on `sky-uat`
- backend `types.test.ts` cannot start its testcontainers because Docker Desktop/containerd returns `file exists` while creating the container task
