### PR TITLE
Make Audio Pipeline status representative

### DIFF
--- a/backend/app/lib/jobs/job-chain.test.ts
+++ b/backend/app/lib/jobs/job-chain.test.ts
@@ -1,0 +1,14 @@
+import { expect } from "@std/expect";
+import { shouldContinueJobChain } from "./job-chain.ts";
+
+Deno.test("job chaining continues only after measurable progress", () => {
+  expect(shouldContinueJobChain({ hasMore: true, processed: 1 })).toBe(true);
+  expect(shouldContinueJobChain({ hasMore: true, processed: 25 })).toBe(true);
+});
+
+Deno.test("job chaining stops when work is exhausted or no progress was made", () => {
+  expect(shouldContinueJobChain({ hasMore: false, processed: 10 })).toBe(false);
+  expect(shouldContinueJobChain({ hasMore: true, processed: 0 })).toBe(false);
+  expect(shouldContinueJobChain({ hasMore: true })).toBe(false);
+  expect(shouldContinueJobChain(undefined)).toBe(false);
+});

--- a/backend/app/lib/jobs/job-chain.ts
+++ b/backend/app/lib/jobs/job-chain.ts
@@ -1,0 +1,15 @@
+/**
+ * Continue automatic batch processing only when the previous run both reports
+ * more work and proves that it made progress. This prevents a worker that is
+ * stuck on the same input from creating an endless sequence of jobs.
+ */
+export function shouldContinueJobChain(
+  result: unknown,
+): boolean {
+  if (!result || typeof result !== "object") return false;
+  const value = result as Record<string, unknown>;
+  return value.hasMore === true &&
+    typeof value.processed === "number" &&
+    Number.isFinite(value.processed) &&
+    value.processed > 0;
+}

--- a/backend/app/lib/jobs/workers.ts
+++ b/backend/app/lib/jobs/workers.ts
@@ -9,6 +9,7 @@ import { getMongoResource } from "@/lib/mongo/core.server.ts";
 import { workerPauseManager } from "./worker-pause-manager.ts";
 import { env } from "#/env.ts";
 import { getServerConfig } from "@/lib/config/serverConfig.server.ts";
+import { shouldContinueJobChain } from "./job-chain.ts";
 
 const workers: Worker[] = [];
 
@@ -116,11 +117,15 @@ export async function startWorkers() {
       console.log(`[${jobType}] Local worker completed job ${job.id}`);
       console.log(`[${jobType}] Job ${job.id} result:`, JSON.stringify(job.returnvalue));
 
-      if (job.returnvalue?.hasMore === true) {
+      if (shouldContinueJobChain(job.returnvalue)) {
         console.log(`[${jobType}] Scheduling another job for ${job.data.type} because hasMore is true`);
         enqueueJob(job.data, {
           trigger: { type: "auto", reason: "hasMore" },
         });
+      } else if (job.returnvalue?.hasMore === true) {
+        console.warn(
+          `[${jobType}] Not scheduling another ${job.data.type} job because the previous run made no measurable progress`,
+        );
       }
     });
 

--- a/backend/app/routes/api.audio.pipeline.ts
+++ b/backend/app/routes/api.audio.pipeline.ts
@@ -3,10 +3,26 @@ import { authenticateOr401 } from "@/lib/auth/core.server.ts";
 import { getMongoResource } from "@/lib/mongo/core.server.ts";
 import { EJSON } from "bson";
 import { ObjectId } from "mongodb";
+import { getServerConfig } from "@/lib/config/serverConfig.server.ts";
+
+const PIPELINE_STAGES = [
+  { type: "ingestion", label: "Ingestion" },
+  { type: "vad", label: "Voice activity" },
+  { type: "transcription_sequence_creator", label: "Sequence creation" },
+  { type: "transcription", label: "Transcription" },
+  { type: "conversation_chunk_creator", label: "Conversation chunks" },
+  { type: "conversation_extractor", label: "Conversation extraction" },
+  { type: "summarization", label: "Summarization" },
+] as const;
 
 interface PipelineSession {
   _id: string;
-  start: Date;
+  start?: Date;
+  lastActivityAt?: Date;
+  path?: string;
+  sourceKind: string;
+  ingested: boolean;
+  ingestionError?: string;
   client_id?: string;
   device?: string;
   metadata?: {
@@ -91,7 +107,56 @@ interface PipelineStats {
   sequencesError: number;
   convChunksReady: number;
   convChunksProcessing: number;
+  convChunksError: number;
   totalConversations: number;
+  sourceFiles: {
+    total: number;
+    ingested: number;
+    pending: number;
+    errors: number;
+    byKind: Array<{ kind: string; count: number }>;
+  };
+  stages: Array<{
+    type: string;
+    label: string;
+    backlog: number;
+    errors: number;
+    paused: boolean;
+    active: number;
+    waiting: number;
+    delayed: number;
+    failed: number;
+    latestJob?: {
+      id: string;
+      state: string;
+      updatedAt?: Date;
+      failedReason?: string;
+    };
+  }>;
+  recentJobs: Array<{
+    id: string;
+    type: string;
+    state: string;
+    createdAt?: Date;
+    updatedAt?: Date;
+    startedAt?: Date;
+    finishedAt?: Date;
+    failedReason?: string;
+    progress?: Record<string, unknown>;
+    result?: Record<string, unknown>;
+  }>;
+}
+
+function sourceKind(sourceFile: any): string {
+  return sourceFile.metadata?.source ?? sourceFile.importer ??
+    sourceFile.platform?.importer ?? sourceFile.platform?.system ?? "unknown";
+}
+
+function ingestionError(sourceFile: any): string | undefined {
+  const error = sourceFile.ingestion?.error;
+  if (!error) return undefined;
+  if (typeof error === "string") return error;
+  return error.message ?? JSON.stringify(error);
 }
 
 type VadPipelineStats = Pick<
@@ -271,143 +336,212 @@ export async function apiAudioPipelineHandler(req: Request, res: Response) {
     const limit = Math.min(parseInt(req.query.limit as string) || 10, 100);
     const mongo = getMongoResource(auth);
 
-    // Fetch source files
+    // Source activity and recording time are different. Imported recordings can
+    // be old while their processing is happening now, so order by the newest
+    // known activity timestamp and include every source kind.
     const sourceFiles = await mongo({
-      action: "find",
+      action: "aggregate",
       collection: "source_files",
-      query: { "metadata.source": "websocket" },
-      options: {
-        sort: { start: -1 },
-        limit: limit + 1,
-      },
+      pipeline: [
+        {
+          $addFields: {
+            pipelineLastActivityAt: {
+              $max: [
+                "$updatedAt",
+                "$ingested_at",
+                "$ingestion.last_attempt",
+                "$createdAt",
+                "$start",
+              ],
+            },
+          },
+        },
+        { $sort: { pipelineLastActivityAt: -1, start: -1 } },
+        { $limit: limit + 1 },
+      ],
     }) as any[];
 
     const hasMore = sourceFiles.length > limit;
     const filesToProcess = sourceFiles.slice(0, limit);
 
-    // Process all sessions in parallel
-    const sessions: PipelineSession[] = await Promise.all(
-      filesToProcess.map(async (sf) => {
-        const sourceFileId = sf._id;
-
-        // Aggregate all data for this session in parallel
-        const [
-          totalChunks,
-          vadProcessed,
-          withSpeech,
-          sequences,
-          transcriptionDocs,
-          conversationChunks,
-        ] = await Promise.all([
-          // Count queries
-          mongo({
-            action: "count",
-            collection: "audio_chunks",
-            query: { original_id: sourceFileId },
-          }),
-          mongo({
-            action: "count",
-            collection: "audio_chunks",
-            query: {
-              original_id: sourceFileId,
-              "vad.ran_at": { $exists: true },
+    const sourceIds = filesToProcess.map((sourceFile) => sourceFile._id);
+    const [
+      chunkGroups,
+      sequenceDocs,
+      transcriptionGroups,
+      conversationChunkDocs,
+    ] = sourceIds.length > 0
+      ? await Promise.all([
+        mongo({
+          action: "aggregate",
+          collection: "audio_chunks",
+          pipeline: [
+            { $match: { original_id: { $in: sourceIds } } },
+            {
+              $group: {
+                _id: "$original_id",
+                total: { $sum: 1 },
+                vadProcessed: {
+                  $sum: { $cond: [{ $ne: ["$vad.ran_at", null] }, 1, 0] },
+                },
+                withSpeech: {
+                  $sum: { $cond: [{ $eq: ["$vad.has_speech", true] }, 1, 0] },
+                },
+              },
             },
-          }),
-          mongo({
-            action: "count",
-            collection: "audio_chunks",
-            query: {
-              original_id: sourceFileId,
-              "vad.has_speech": true,
+          ],
+        }),
+        mongo({
+          action: "find",
+          collection: "transcription_sequences",
+          query: { original_id: { $in: sourceIds } },
+          options: { sort: { start: -1 } },
+        }),
+        mongo({
+          action: "aggregate",
+          collection: "transcriptions",
+          pipeline: [
+            { $match: { original: { $in: sourceIds } } },
+            { $sort: { start: 1 } },
+            {
+              $group: {
+                _id: "$original",
+                count: { $sum: 1 },
+                details: {
+                  $push: {
+                    _id: "$_id",
+                    start: "$start",
+                    end: "$end",
+                    text: "$text",
+                    segments: "$segments",
+                  },
+                },
+              },
             },
-          }),
-          // Find queries
-          mongo({
-            action: "find",
-            collection: "transcription_sequences",
-            query: { original_id: sourceFileId },
-            options: { sort: { start: -1 } },
-          }),
-          mongo({
-            action: "find",
-            collection: "transcriptions",
-            query: { original: sourceFileId },
-            options: { sort: { start: 1 }, limit: 20 },
-          }),
-          mongo({
-            action: "find",
-            collection: "conversation_chunks",
-            query: { original_id: sourceFileId },
-            options: { sort: { createdAt: -1 } },
-          }),
-        ]);
+            { $project: { count: 1, details: { $slice: ["$details", 20] } } },
+          ],
+        }),
+        mongo({
+          action: "find",
+          collection: "conversation_chunks",
+          query: { original_id: { $in: sourceIds } },
+          options: { sort: { createdAt: -1 } },
+        }),
+      ])
+      : [[], [], [], []];
 
-        // Get conversations for this session via conversation chunks
-        const chunkIds = conversationChunks.map((c: any) => c._id.toString());
-        const conversations = chunkIds.length > 0
-          ? await mongo({
-            action: "find",
-            collection: "objects",
-            query: {
-              isConversation: true,
-              "metadata.extractedWith.chunkId": { $in: chunkIds },
-            },
-            options: { sort: { createdAt: -1 } },
-          })
-          : [];
-
-        return {
-          _id: sf._id.toString(),
-          start: sf.start,
-          client_id: sf.client_id,
-          device: sf.device,
-          metadata: sf.metadata,
-          processing_status: sf.processing_status,
-          chunks: {
-            total: totalChunks,
-            vadProcessed,
-            withSpeech,
-          },
-          sequences: sequences.map((s: any) => ({
-            _id: s._id.toString(),
-            state: s.state,
-            chunk_count: s.chunk_count,
-            fromIndex: s.fromIndex,
-            toIndex: s.toIndex,
-            updatedAt: s.updatedAt,
-            error: s.error,
-          })),
-          transcriptions: transcriptionDocs.length,
-          conversationChunks: conversationChunks.map((c: any) => ({
-            _id: c._id.toString(),
-            state: c.state,
-            mode: c.mode,
-            transcriptionCount: c.transcriptionCount || 0,
-            totalTextLength: c.totalTextLength || 0,
-            start: c.start,
-            end: c.end,
-            updatedAt: c.updatedAt,
-            error: c.error,
-            emptyReason: c.emptyReason,
-            segmentsFound: c.segmentsFound,
-            conversationsCreated: c.conversationsCreated,
-          })),
-          transcriptionDetails: transcriptionDocs.map((t: any) => ({
-            _id: t._id.toString(),
-            start: t.start,
-            end: t.end,
-            text: t.segments?.map((s: any) => s.text).join("") || t.text || "",
-          })),
-          conversations: conversations.map((c: any) => ({
-            _id: c._id.toString(),
-            name: c.name,
-            icon: c.icon,
-            timeRanges: c.timeRanges,
-            createdAt: c.createdAt,
-          })),
-        };
-      }),
+    const chunkIds = conversationChunkDocs.map((chunk: any) =>
+      chunk._id.toString()
     );
+    const conversationDocs = chunkIds.length > 0
+      ? await mongo({
+        action: "find",
+        collection: "objects",
+        query: {
+          isConversation: true,
+          "metadata.extractedWith.chunkId": { $in: chunkIds },
+        },
+        options: { sort: { createdAt: -1 } },
+      }) as any[]
+      : [];
+
+    const groupBy = (docs: any[], field: string) => {
+      const grouped = new Map<string, any[]>();
+      for (const doc of docs) {
+        const key = doc[field]?.toString();
+        if (!key) continue;
+        grouped.set(key, [...(grouped.get(key) ?? []), doc]);
+      }
+      return grouped;
+    };
+    const chunkStatsBySource = new Map<string, any>(
+      chunkGroups.map((group: any) => [group._id.toString(), group]),
+    );
+    const sequencesBySource = groupBy(sequenceDocs, "original_id");
+    const transcriptionBySource = new Map<string, any>(
+      transcriptionGroups.map((group: any) => [group._id.toString(), group]),
+    );
+    const conversationChunksBySource = groupBy(
+      conversationChunkDocs,
+      "original_id",
+    );
+    const conversationsByChunk = groupBy(
+      conversationDocs.map((conversation: any) => ({
+        ...conversation,
+        chunkId: conversation.metadata?.extractedWith?.chunkId,
+      })),
+      "chunkId",
+    );
+
+    const sessions: PipelineSession[] = filesToProcess.map((sf) => {
+      const id = sf._id.toString();
+      const chunkStats = chunkStatsBySource.get(id) ?? {};
+      const sequences = sequencesBySource.get(id) ?? [];
+      const transcriptionGroup = transcriptionBySource.get(id) ?? {
+        count: 0,
+        details: [],
+      };
+      const conversationChunks = conversationChunksBySource.get(id) ?? [];
+      const conversations = conversationChunks.flatMap((chunk: any) =>
+        conversationsByChunk.get(chunk._id.toString()) ?? []
+      );
+
+      return {
+        _id: sf._id.toString(),
+        start: sf.start,
+        lastActivityAt: sf.pipelineLastActivityAt ?? sf.start,
+        path: sf.path,
+        sourceKind: sourceKind(sf),
+        ingested: sf.ingested === true,
+        ingestionError: ingestionError(sf),
+        client_id: sf.client_id,
+        device: sf.device,
+        metadata: sf.metadata,
+        processing_status: sf.processing_status,
+        chunks: {
+          total: chunkStats.total ?? 0,
+          vadProcessed: chunkStats.vadProcessed ?? 0,
+          withSpeech: chunkStats.withSpeech ?? 0,
+        },
+        sequences: sequences.map((s: any) => ({
+          _id: s._id.toString(),
+          state: s.state,
+          chunk_count: s.chunk_count,
+          fromIndex: s.fromIndex,
+          toIndex: s.toIndex,
+          updatedAt: s.updatedAt,
+          error: s.error,
+        })),
+        transcriptions: transcriptionGroup.count,
+        conversationChunks: conversationChunks.map((c: any) => ({
+          _id: c._id.toString(),
+          state: c.state,
+          mode: c.mode,
+          transcriptionCount: c.transcriptionCount || 0,
+          totalTextLength: c.totalTextLength || 0,
+          start: c.start,
+          end: c.end,
+          updatedAt: c.updatedAt,
+          error: c.error,
+          emptyReason: c.emptyReason,
+          segmentsFound: c.segmentsFound,
+          conversationsCreated: c.conversationsCreated,
+        })),
+        transcriptionDetails: transcriptionGroup.details.map((t: any) => ({
+          _id: t._id.toString(),
+          start: t.start,
+          end: t.end,
+          text: t.segments?.map((s: any) => s.text).join("") || t.text || "",
+        })),
+        conversations: conversations.map((c: any) => ({
+          _id: c._id.toString(),
+          name: c.name,
+          icon: c.icon,
+          timeRanges: c.timeRanges,
+          createdAt: c.createdAt,
+        })),
+      };
+    });
 
     // Get global stats in parallel. VAD stats are cached because this endpoint
     // auto-refreshes and the chunk collection can contain hundreds of thousands
@@ -419,7 +553,16 @@ export async function apiAudioPipelineHandler(req: Request, res: Response) {
       sequencesError,
       convChunksReady,
       convChunksProcessing,
+      convChunksError,
       totalConversations,
+      sourceStatsResult,
+      sourceKinds,
+      pendingSequenceChunks,
+      unassignedTranscriptions,
+      conversationsAwaitingSummary,
+      jobStatsResult,
+      recentJobsResult,
+      serverConfig,
     ] = await Promise.all([
       getVadPipelineStats(mongo),
       mongo({
@@ -449,20 +592,251 @@ export async function apiAudioPipelineHandler(req: Request, res: Response) {
       }),
       mongo({
         action: "count",
+        collection: "conversation_chunks",
+        query: { state: "error" },
+      }),
+      mongo({
+        action: "count",
         collection: "objects",
         query: { isConversation: true },
       }),
+      mongo({
+        action: "aggregate",
+        collection: "source_files",
+        pipeline: [{
+          $group: {
+            _id: null,
+            total: { $sum: 1 },
+            ingested: {
+              $sum: { $cond: [{ $eq: ["$ingested", true] }, 1, 0] },
+            },
+            errors: {
+              $sum: {
+                $cond: [
+                  {
+                    $and: [
+                      { $ne: ["$ingested", true] },
+                      {
+                        $ne: [
+                          { $ifNull: ["$ingestion.error", null] },
+                          null,
+                        ],
+                      },
+                    ],
+                  },
+                  1,
+                  0,
+                ],
+              },
+            },
+            pending: {
+              $sum: {
+                $cond: [
+                  {
+                    $and: [
+                      { $ne: ["$ingested", true] },
+                      {
+                        $eq: [
+                          { $ifNull: ["$ingestion.error", null] },
+                          null,
+                        ],
+                      },
+                    ],
+                  },
+                  1,
+                  0,
+                ],
+              },
+            },
+          },
+        }],
+      }),
+      mongo({
+        action: "aggregate",
+        collection: "source_files",
+        pipeline: [
+          {
+            $project: {
+              kind: {
+                $ifNull: [
+                  "$metadata.source",
+                  {
+                    $ifNull: [
+                      "$importer",
+                      {
+                        $ifNull: [
+                          "$platform.importer",
+                          { $ifNull: ["$platform.system", "unknown"] },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+          { $group: { _id: "$kind", count: { $sum: 1 } } },
+          { $sort: { count: -1 } },
+        ],
+      }),
+      mongo({
+        action: "count",
+        collection: "audio_chunks",
+        query: {
+          "vad.has_speech": true,
+          transcribed_at: { $eq: null },
+          transcription_sequence_id: { $exists: false },
+        },
+      }),
+      mongo({
+        action: "count",
+        collection: "transcriptions",
+        query: { chunk_id: { $exists: false } },
+      }),
+      mongo({
+        action: "count",
+        collection: "objects",
+        query: { isConversation: true, "summaries.0": { $exists: false } },
+      }),
+      mongo({
+        action: "aggregate",
+        collection: "jobs",
+        pipeline: [
+          {
+            $match: {
+              type: { $in: PIPELINE_STAGES.map((stage) => stage.type) },
+            },
+          },
+          { $sort: { updatedAt: -1, createdAt: -1 } },
+          {
+            $group: {
+              _id: "$type",
+              active: {
+                $sum: { $cond: [{ $eq: ["$state", "active"] }, 1, 0] },
+              },
+              waiting: {
+                $sum: { $cond: [{ $eq: ["$state", "waiting"] }, 1, 0] },
+              },
+              delayed: {
+                $sum: { $cond: [{ $eq: ["$state", "delayed"] }, 1, 0] },
+              },
+              failed: {
+                $sum: { $cond: [{ $eq: ["$state", "failed"] }, 1, 0] },
+              },
+              latestJob: {
+                $first: {
+                  id: "$_id",
+                  state: "$state",
+                  updatedAt: { $ifNull: ["$updatedAt", "$createdAt"] },
+                  failedReason: "$failedReason",
+                },
+              },
+            },
+          },
+        ],
+      }),
+      mongo({
+        action: "find",
+        collection: "jobs",
+        query: { type: { $in: PIPELINE_STAGES.map((stage) => stage.type) } },
+        options: {
+          sort: { updatedAt: -1, createdAt: -1 },
+          limit: 12,
+          projection: {
+            type: 1,
+            state: 1,
+            createdAt: 1,
+            updatedAt: 1,
+            startedAt: 1,
+            finishedAt: 1,
+            failedReason: 1,
+            progress: 1,
+            result: 1,
+          },
+        },
+      }),
+      getServerConfig().catch((error: unknown) => {
+        console.warn("[apiAudioPipelineHandler] config unavailable:", error);
+        return { workers: {} } as any;
+      }),
     ]);
 
+    const sourceTotals = sourceStatsResult[0] ?? {};
+    const sourceFilesStats = {
+      total: sourceTotals.total ?? 0,
+      ingested: sourceTotals.ingested ?? 0,
+      pending: sourceTotals.pending ?? 0,
+      errors: sourceTotals.errors ?? 0,
+      byKind: sourceKinds.map((row: any) => ({
+        kind: row._id ?? "unknown",
+        count: row.count,
+      })),
+    };
+    const jobStats = new Map<string, any>(
+      jobStatsResult.map((row: any) => [row._id, row]),
+    );
+    const backlogs: Record<string, number> = {
+      ingestion: sourceFilesStats.pending + sourceFilesStats.errors,
+      vad: vadStats.chunksAwaitingVad,
+      transcription_sequence_creator: pendingSequenceChunks,
+      transcription: sequencesReady + sequencesProcessing + sequencesError,
+      conversation_chunk_creator: unassignedTranscriptions,
+      conversation_extractor: convChunksReady + convChunksProcessing +
+        convChunksError,
+      summarization: conversationsAwaitingSummary,
+    };
+    const stageErrors: Record<string, number> = {
+      ingestion: sourceFilesStats.errors,
+      vad: vadStats.vadJobs.failed,
+      transcription: sequencesError,
+      conversation_extractor: convChunksError,
+    };
+    const stages = PIPELINE_STAGES.map(({ type, label }) => {
+      const jobs = jobStats.get(type) ?? {};
+      const latestJob = jobs.latestJob
+        ? {
+          ...jobs.latestJob,
+          id: jobs.latestJob.id.toString(),
+        }
+        : undefined;
+      return {
+        type,
+        label,
+        backlog: backlogs[type] ?? 0,
+        errors: stageErrors[type] ?? 0,
+        paused: serverConfig.workers?.[type]?.paused === true,
+        active: jobs.active ?? 0,
+        waiting: jobs.waiting ?? 0,
+        delayed: jobs.delayed ?? 0,
+        failed: jobs.failed ?? 0,
+        latestJob,
+      };
+    });
+
     const stats: PipelineStats = {
-      totalSessions: sessions.length,
+      totalSessions: sourceFilesStats.total,
       ...vadStats,
       sequencesReady,
       sequencesProcessing,
       sequencesError,
       convChunksReady,
       convChunksProcessing,
+      convChunksError,
       totalConversations,
+      sourceFiles: sourceFilesStats,
+      stages,
+      recentJobs: recentJobsResult.map((job: any) => ({
+        id: job._id.toString(),
+        type: job.type,
+        state: job.state,
+        createdAt: job.createdAt,
+        updatedAt: job.updatedAt,
+        startedAt: job.startedAt,
+        finishedAt: job.finishedAt,
+        failedReason: job.failedReason,
+        progress: job.progress,
+        result: job.result,
+      })),
     };
 
     // Serialize dates properly

--- a/backend/app/tests/api.audio.pipeline.test.ts
+++ b/backend/app/tests/api.audio.pipeline.test.ts
@@ -35,6 +35,19 @@ Deno.test(
     expect(typeof data.stats.vadJobs).toBe("object");
     expect(typeof data.stats.vadJobs.active).toBe("number");
     expect(typeof data.stats.vadJobs.failed).toBe("number");
+    expect(typeof data.stats.sourceFiles.total).toBe("number");
+    expect(Array.isArray(data.stats.sourceFiles.byKind)).toBe(true);
+    expect(Array.isArray(data.stats.stages)).toBe(true);
+    expect(data.stats.stages.map((stage: any) => stage.type)).toEqual([
+      "ingestion",
+      "vad",
+      "transcription_sequence_creator",
+      "transcription",
+      "conversation_chunk_creator",
+      "conversation_extractor",
+      "summarization",
+    ]);
+    expect(Array.isArray(data.stats.recentJobs)).toBe(true);
   }),
 );
 

--- a/backend/workers/conversationChunkCreator.ts
+++ b/backend/workers/conversationChunkCreator.ts
@@ -762,6 +762,7 @@ const capability: JobCapability = {
     streamed: z.number(),
     backfilled: z.number(),
     chunksCreated: z.number(),
+    processed: z.number(),
     hasMore: z.boolean(),
   })),
   policies: [
@@ -813,6 +814,7 @@ const capability: JobCapability = {
         streamed: 0,
         backfilled: result.transcriptionsProcessed,
         chunksCreated: result.chunksCreated,
+        processed: result.transcriptionsProcessed,
         hasMore: result.hasMore,
       };
     }
@@ -879,6 +881,7 @@ const capability: JobCapability = {
       streamed: totalStreamed,
       backfilled: totalBackfilled,
       chunksCreated: totalChunksCreated,
+      processed: totalFinalized + totalStreamed + totalBackfilled,
       hasMore,
     };
 

--- a/backend/workers/conversationExtractor.ts
+++ b/backend/workers/conversationExtractor.ts
@@ -932,6 +932,7 @@ const capability: JobCapability = {
     success: z.boolean(),
     conversationsCreated: z.number(),
     chunksProcessed: z.number(),
+    processed: z.number(),
     hasMore: z.boolean(),
     errors: z.array(z.object({
       type: z.string(),
@@ -1050,6 +1051,7 @@ const capability: JobCapability = {
       success: errors.length === 0,
       conversationsCreated,
       chunksProcessed,
+      processed: chunksProcessed,
       hasMore,
       ...(errors.length > 0 && { errors }),
     };

--- a/backend/workers/tagger.ts
+++ b/backend/workers/tagger.ts
@@ -311,6 +311,7 @@ const capability: JobCapability = {
     status: z.literal("completed"),
     success: z.boolean(),
     conversationsProcessed: z.number(),
+    processed: z.number(),
     tagsApplied: z.number(),
     hasMore: z.boolean(),
     errors: z.array(z.object({
@@ -349,6 +350,7 @@ const capability: JobCapability = {
         status: "completed" as const,
         success: true,
         conversationsProcessed: 0,
+        processed: 0,
         tagsApplied: 0,
         hasMore: false,
       };
@@ -387,6 +389,7 @@ const capability: JobCapability = {
         status: "completed" as const,
         success: true,
         conversationsProcessed: 0,
+        processed: 0,
         tagsApplied: 0,
         hasMore: false,
       };
@@ -527,6 +530,7 @@ const capability: JobCapability = {
       status: "completed" as const,
       success: errors.length === 0,
       conversationsProcessed,
+      processed: conversationsProcessed,
       tagsApplied,
       hasMore,
       ...(errors.length > 0 && { errors }),

--- a/backend/workers/transcription.ts
+++ b/backend/workers/transcription.ts
@@ -193,6 +193,7 @@ const capability: JobCapability = {
           return { 
             status: "success", 
             result: "empty",
+            processed: 1,
             transcriptionId: null,
             audioDuration: 0,
             wordCount: 0,
@@ -297,6 +298,7 @@ const capability: JobCapability = {
         return { 
           status: "success", 
           result: "transcribed",
+          processed: 1,
           transcriptionId,
           audioDuration: duration,
           audioSize: combinedAudio.length,

--- a/frontend/src/pages/AudioPipelinePage.tsx
+++ b/frontend/src/pages/AudioPipelinePage.tsx
@@ -23,6 +23,7 @@ import {
   Activity,
   AlertCircle,
   AudioWaveform,
+  CheckCircle2,
   ChevronRight,
   Clock,
   FileText,
@@ -30,6 +31,7 @@ import {
   Layers,
   MessageSquare,
   Mic,
+  PauseCircle,
   RefreshCw,
   Timer,
   Trash2,
@@ -42,7 +44,12 @@ import {
 
 interface AudioSession {
   _id: string;
-  start: Date;
+  start?: Date;
+  lastActivityAt?: Date;
+  path?: string;
+  sourceKind: string;
+  ingested: boolean;
+  ingestionError?: string;
   client_id?: string;
   device?: string;
   metadata?: {
@@ -127,7 +134,46 @@ interface PipelineStats {
   sequencesError: number;
   convChunksReady: number;
   convChunksProcessing: number;
+  convChunksError: number;
   totalConversations: number;
+  sourceFiles: {
+    total: number;
+    ingested: number;
+    pending: number;
+    errors: number;
+    byKind: Array<{ kind: string; count: number }>;
+  };
+  stages: PipelineStage[];
+  recentJobs: PipelineJob[];
+}
+
+interface PipelineStage {
+  type: string;
+  label: string;
+  backlog: number;
+  errors: number;
+  paused: boolean;
+  active: number;
+  waiting: number;
+  delayed: number;
+  failed: number;
+  latestJob?: {
+    id: string;
+    state: string;
+    updatedAt?: Date;
+    failedReason?: string;
+  };
+}
+
+interface PipelineJob {
+  id: string;
+  type: string;
+  state: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+  startedAt?: Date;
+  finishedAt?: Date;
+  failedReason?: string;
 }
 
 const DEFAULT_SESSION_LIMIT = 10;
@@ -140,6 +186,33 @@ function formatEta(seconds?: number): string {
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.ceil((seconds % 3600) / 60);
   return `About ${hours}h${minutes ? ` ${minutes}m` : ""}`;
+}
+
+function stageState(stage: PipelineStage): {
+  label: string;
+  className: string;
+} {
+  if (stage.paused && stage.backlog > 0) {
+    return { label: "Blocked · paused", className: "text-red-600" };
+  }
+  if (stage.active > 0) {
+    return { label: `${stage.active} running`, className: "text-blue-600" };
+  }
+  const queued = stage.waiting + stage.delayed;
+  if (queued > 0) {
+    return { label: `${queued} queued`, className: "text-amber-600" };
+  }
+  if (stage.errors > 0) {
+    return { label: `${stage.errors} errors`, className: "text-red-600" };
+  }
+  if (stage.backlog > 0) {
+    return { label: "Waiting for worker", className: "text-amber-600" };
+  }
+  return { label: "Caught up", className: "text-green-600" };
+}
+
+function formatWorkerType(type: string): string {
+  return type.replaceAll("_", " ");
 }
 
 export default function AudioPipelinePage() {
@@ -174,7 +247,14 @@ export default function AudioPipelinePage() {
       // Convert any remaining date strings to Date objects
       const sessions: AudioSession[] = deserialized.sessions.map((s: any) => ({
         ...s,
-        start: s.start instanceof Date ? s.start : new Date(s.start),
+        start: s.start
+          ? (s.start instanceof Date ? s.start : new Date(s.start))
+          : undefined,
+        lastActivityAt: s.lastActivityAt
+          ? (s.lastActivityAt instanceof Date
+            ? s.lastActivityAt
+            : new Date(s.lastActivityAt))
+          : undefined,
         sequences: s.sequences.map((seq: any) => ({
           ...seq,
           updatedAt: seq.updatedAt
@@ -232,6 +312,24 @@ export default function AudioPipelinePage() {
             }),
           ),
         },
+        stages: (rawStats.stages ?? []).map((stage) => ({
+          ...stage,
+          latestJob: stage.latestJob
+            ? {
+              ...stage.latestJob,
+              updatedAt: stage.latestJob.updatedAt
+                ? new Date(stage.latestJob.updatedAt)
+                : undefined,
+            }
+            : undefined,
+        })),
+        recentJobs: (rawStats.recentJobs ?? []).map((job) => ({
+          ...job,
+          createdAt: job.createdAt ? new Date(job.createdAt) : undefined,
+          updatedAt: job.updatedAt ? new Date(job.updatedAt) : undefined,
+          startedAt: job.startedAt ? new Date(job.startedAt) : undefined,
+          finishedAt: job.finishedAt ? new Date(job.finishedAt) : undefined,
+        })),
       };
 
       return {
@@ -260,6 +358,21 @@ export default function AudioPipelinePage() {
   const vadMaximumAudioHours = getMaximumAudioHours(
     stats?.chunksAwaitingVad ?? 0,
   );
+  const activeStages = stats?.stages.filter((stage) => stage.active > 0) ?? [];
+  const blockedStages = stats?.stages.filter(
+    (stage) => stage.paused && stage.backlog > 0,
+  ) ?? [];
+  const stagesWithErrors = stats?.stages.filter((stage) => stage.errors > 0) ??
+    [];
+  const pipelineHealth = !stats
+    ? "loading"
+    : blockedStages.length > 0
+    ? "blocked"
+    : activeStages.length > 0
+    ? "processing"
+    : stagesWithErrors.length > 0
+    ? "attention"
+    : "idle";
 
   const clearFailedVadMutation = useMutation({
     mutationFn: async () => {
@@ -311,10 +424,14 @@ export default function AudioPipelinePage() {
       case "completed":
         return "bg-green-500/10 text-green-500";
       case "ready":
+      case "waiting":
         return "bg-blue-500/10 text-blue-500";
       case "processing":
+      case "active":
+      case "delayed":
         return "bg-yellow-500/10 text-yellow-500";
       case "error":
+      case "failed":
         return "bg-red-500/10 text-red-500";
       case "empty":
         return "bg-gray-500/10 text-gray-500";
@@ -379,7 +496,7 @@ export default function AudioPipelinePage() {
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Audio Pipeline</h1>
           <p className="text-muted-foreground">
-            Track audio sessions through VAD and transcription
+            Live state from source ingestion through conversations and summaries
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -404,6 +521,180 @@ export default function AudioPipelinePage() {
             Refresh
           </Button>
         </div>
+      </div>
+
+      <Card
+        className={pipelineHealth === "loading"
+          ? "border-muted bg-muted/10"
+          : pipelineHealth === "blocked"
+          ? "border-red-500/50 bg-red-500/5"
+          : pipelineHealth === "processing"
+          ? "border-blue-500/40 bg-blue-500/5"
+          : pipelineHealth === "attention"
+          ? "border-amber-500/40 bg-amber-500/5"
+          : "border-green-500/30 bg-green-500/5"}
+        data-testid="pipeline-health"
+      >
+        <CardContent className="flex flex-col justify-between gap-4 pt-6 md:flex-row md:items-center">
+          <div className="flex items-start gap-3">
+            {pipelineHealth === "loading"
+              ? <RefreshCw className="mt-0.5 h-5 w-5 animate-spin" />
+              : pipelineHealth === "blocked"
+              ? <PauseCircle className="mt-0.5 h-5 w-5 text-red-600" />
+              : pipelineHealth === "processing"
+              ? (
+                <Activity className="mt-0.5 h-5 w-5 animate-pulse text-blue-600" />
+              )
+              : pipelineHealth === "attention"
+              ? <AlertCircle className="mt-0.5 h-5 w-5 text-amber-600" />
+              : <CheckCircle2 className="mt-0.5 h-5 w-5 text-green-600" />}
+            <div>
+              <p className="font-semibold capitalize">
+                Pipeline {pipelineHealth}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {pipelineHealth === "loading"
+                  ? "Loading source, backlog, worker, and job state."
+                  : blockedStages.length > 0
+                  ? `${blockedStages.map((stage) => stage.label).join(", ")} ${
+                    blockedStages.length === 1 ? "is" : "are"
+                  } paused with work waiting.`
+                  : activeStages.length > 0
+                  ? `${activeStages.map((stage) => stage.label).join(", ")} ${
+                    activeStages.length === 1 ? "is" : "are"
+                  } processing now.`
+                  : stagesWithErrors.length > 0
+                  ? "No worker is active and some stages need attention."
+                  : "No stage has queued work or a current error."}
+              </p>
+            </div>
+          </div>
+          <Link
+            to="/jobs"
+            className="text-sm font-medium text-primary hover:underline"
+          >
+            Open all jobs →
+          </Link>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>End-to-end stage status</CardTitle>
+          <CardDescription>
+            Backlog comes from pipeline collections; running and queued state
+            comes from jobs. Paused workers are called out explicitly.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-7">
+            {(stats?.stages ?? []).map((stage, index) => {
+              const state = stageState(stage);
+              return (
+                <div
+                  key={stage.type}
+                  className="relative rounded-lg border bg-muted/20 p-3"
+                  data-testid={`pipeline-stage-${stage.type}`}
+                >
+                  {index > 0 && (
+                    <ChevronRight className="absolute -left-3 top-1/2 hidden h-5 w-5 -translate-y-1/2 rounded-full bg-background text-muted-foreground xl:block" />
+                  )}
+                  <p className="text-xs font-medium text-muted-foreground">
+                    {index + 1}. {stage.label}
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold">
+                    {stage.backlog.toLocaleString()}
+                  </p>
+                  <p className="text-[11px] text-muted-foreground">
+                    items waiting
+                  </p>
+                  <p className={`mt-2 text-xs font-medium ${state.className}`}>
+                    {state.label}
+                  </p>
+                  {stage.latestJob && (
+                    <Link
+                      to={`/jobs/${stage.latestJob.id}`}
+                      className="mt-2 block truncate text-[11px] text-primary hover:underline"
+                    >
+                      Latest: {stage.latestJob.state}
+                    </Link>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 lg:grid-cols-[1fr_1.4fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Audio sources</CardTitle>
+            <CardDescription>
+              Every source type, not only legacy websocket recordings.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-2 xl:grid-cols-4">
+              {[
+                ["Total", stats?.sourceFiles.total ?? 0],
+                ["Ingested", stats?.sourceFiles.ingested ?? 0],
+                ["Pending", stats?.sourceFiles.pending ?? 0],
+                ["Errors", stats?.sourceFiles.errors ?? 0],
+              ].map(([label, value]) => (
+                <div key={label} className="rounded-lg bg-muted/40 p-3">
+                  <p className="text-xs text-muted-foreground">{label}</p>
+                  <p className="mt-1 text-xl font-semibold">
+                    {(value as number).toLocaleString()}
+                  </p>
+                </div>
+              ))}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {(stats?.sourceFiles.byKind ?? []).map((source) => (
+                <Badge key={source.kind} variant="outline">
+                  {source.kind}: {source.count.toLocaleString()}
+                </Badge>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Latest pipeline jobs</CardTitle>
+            <CardDescription>
+              This activity can belong to older recordings, so it is shown
+              separately from recently added sources.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {(stats?.recentJobs ?? []).slice(0, 6).map((job) => (
+              <Link
+                key={job.id}
+                to={`/jobs/${job.id}`}
+                className="flex items-center justify-between gap-4 rounded-md border p-2.5 hover:bg-muted/40"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium capitalize">
+                    {formatWorkerType(job.type)}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {job.updatedAt
+                      ? formatDistanceToNow(job.updatedAt, { addSuffix: true })
+                      : "time unavailable"}
+                  </p>
+                </div>
+                <Badge className={getStateColor(job.state)}>{job.state}</Badge>
+              </Link>
+            ))}
+            {(stats?.recentJobs?.length ?? 0) === 0 && (
+              <p className="py-5 text-center text-sm text-muted-foreground">
+                No pipeline jobs recorded yet.
+              </p>
+            )}
+          </CardContent>
+        </Card>
       </div>
 
       {/* Pipeline Stats */}
@@ -651,9 +942,10 @@ export default function AudioPipelinePage() {
       {/* Sessions List */}
       <Card>
         <CardHeader>
-          <CardTitle>Recent Audio Sessions</CardTitle>
+          <CardTitle>Recently active audio sources</CardTitle>
           <CardDescription>
-            Click a session to see detailed pipeline status
+            Ordered by ingestion or processing activity, not only by recording
+            time. Click a source to see its downstream records.
           </CardDescription>
         </CardHeader>
         <CardContent className="p-0">
@@ -666,7 +958,7 @@ export default function AudioPipelinePage() {
             : !sessions?.length
             ? (
               <div className="p-8 text-center text-muted-foreground">
-                No audio sessions found
+                No audio sources found
               </div>
             )
             : (
@@ -679,14 +971,33 @@ export default function AudioPipelinePage() {
                   >
                     <CollapsibleTrigger asChild>
                       <div
-                        className="flex items-center justify-between p-4 hover:bg-muted/50 cursor-pointer"
+                        className="flex cursor-pointer flex-col gap-4 p-4 hover:bg-muted/50 xl:flex-row xl:items-center xl:justify-between"
                         data-testid={`session-row-${session._id}`}
                       >
                         <div className="flex items-center gap-4">
                           <Mic className="h-5 w-5 text-muted-foreground" />
                           <div>
                             <div className="font-medium flex items-center gap-2">
-                              {format(session.start, "MMM d, HH:mm:ss")}
+                              {session.start
+                                ? format(session.start, "MMM d, HH:mm:ss")
+                                : session.path?.split("/").pop() ||
+                                  "Recording time unavailable"}
+                              <Badge variant="outline" className="font-normal">
+                                {session.sourceKind}
+                              </Badge>
+                              <Badge
+                                className={session.ingestionError
+                                  ? "bg-red-500/10 text-red-600"
+                                  : session.ingested
+                                  ? "bg-green-500/10 text-green-600"
+                                  : "bg-amber-500/10 text-amber-600"}
+                              >
+                                {session.ingestionError
+                                  ? "ingestion error"
+                                  : session.ingested
+                                  ? "ingested"
+                                  : "pending"}
+                              </Badge>
                               {session.client_id && (
                                 <span className="text-xs px-2 py-0.5 bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 rounded">
                                   {session.device || session.client_id}
@@ -697,17 +1008,29 @@ export default function AudioPipelinePage() {
                               {session.metadata?.codec ||
                                 session.metadata?.format || "unknown"}{" "}
                               {session.metadata?.rate}Hz &middot;{" "}
-                              {formatDistanceToNow(session.start, {
-                                addSuffix: true,
-                              })} &middot;{" "}
+                              {session.lastActivityAt
+                                ? `active ${
+                                  formatDistanceToNow(session.lastActivityAt, {
+                                    addSuffix: true,
+                                  })
+                                } · `
+                                : ""}
                               <span className="font-mono text-xs">
                                 {session._id.substring(0, 8)}
                               </span>
                             </div>
+                            {session.path && (
+                              <div
+                                className="max-w-xl truncate text-xs text-muted-foreground"
+                                title={session.path}
+                              >
+                                {session.path}
+                              </div>
+                            )}
                           </div>
                         </div>
 
-                        <div className="flex items-center gap-6">
+                        <div className="flex w-full items-center gap-6 overflow-x-auto pb-1 xl:w-auto xl:pb-0">
                           {/* Pipeline stages mini-view */}
                           <div className="flex items-center gap-2">
                             {getStageProgress(session).map((stage, i) => (
@@ -743,6 +1066,11 @@ export default function AudioPipelinePage() {
 
                     <CollapsibleContent>
                       <div className="px-4 pb-3 pt-2 bg-muted/30 space-y-3">
+                        {session.ingestionError && (
+                          <div className="rounded-md border border-red-500/30 bg-red-500/5 p-3 text-xs text-red-600">
+                            {session.ingestionError}
+                          </div>
+                        )}
                         {/* Compact stats row */}
                         <div className="flex items-center gap-4 text-xs">
                           <span className="text-muted-foreground">


### PR DESCRIPTION
## Summary
- include every audio source type and order sources by current ingestion/processing activity
- add end-to-end backlog, worker pause state, live job activity, ingestion errors, and source-kind coverage
- replace per-session N+1 reads with batched aggregations
- continue automatic job chains only when a worker reports both `hasMore` and measurable `processed` progress

## Verification
- backend targeted type-check and lint
- job-chain unit tests: 2 passed
- frontend targeted type-check and lint
- frontend Vitest: 2 passed
- frontend production build

## Local environment limits
- Docker-backed API fixture could not start because Docker Desktop has a stale containerd task (`file exists`), before any test assertion ran
- in-app browser policy blocked localhost UI access, so GitHub CI is the final integration gate before merge

## Scope
Unrelated local changes in `frontend/src/pages/TranscriptPage.tsx` are intentionally excluded.