### PR TITLE
Fix Audio Pipeline statistics performance

### DIFF
--- a/backend/app/routes/api.audio.pipeline.ts
+++ b/backend/app/routes/api.audio.pipeline.ts
@@ -15,6 +15,43 @@ const PIPELINE_STAGES = [
   { type: "summarization", label: "Summarization" },
 ] as const;
 
+const PIPELINE_STATS_MAX_TIME_MS = 10_000;
+
+function isMissingIndexHint(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes(
+    "hint provided does not correspond to an existing index",
+  );
+}
+
+async function aggregatePipelineStats(
+  mongo: ReturnType<typeof getMongoResource>,
+  collection: string,
+  pipeline: Record<string, unknown>[],
+  hint: string,
+): Promise<any[]> {
+  try {
+    return await mongo({
+      action: "aggregate",
+      collection,
+      pipeline,
+      options: { hint, maxTimeMS: PIPELINE_STATS_MAX_TIME_MS },
+    });
+  } catch (error) {
+    if (!isMissingIndexHint(error)) throw error;
+
+    console.warn(
+      `[audio-pipeline] Statistics index ${hint} is unavailable; retrying without a hint`,
+    );
+    return await mongo({
+      action: "aggregate",
+      collection,
+      pipeline,
+      options: { maxTimeMS: PIPELINE_STATS_MAX_TIME_MS },
+    });
+  }
+}
+
 interface PipelineSession {
   _id: string;
   start?: Date;
@@ -399,10 +436,10 @@ export async function apiAudioPipelineHandler(req: Request, res: Response) {
       conversationChunkDocs,
     ] = sourceIds.length > 0
       ? await Promise.all([
-        mongo({
-          action: "aggregate",
-          collection: "audio_chunks",
-          pipeline: [
+        aggregatePipelineStats(
+          mongo,
+          "audio_chunks",
+          [
             { $match: { original_id: { $in: sourceIds } } },
             {
               $group: {
@@ -417,7 +454,8 @@ export async function apiAudioPipelineHandler(req: Request, res: Response) {
               },
             },
           ],
-        }),
+          "audio_chunks_pipeline_source_stats",
+        ),
         mongo({
           action: "find",
           collection: "transcription_sequences",
@@ -584,7 +622,7 @@ export async function apiAudioPipelineHandler(req: Request, res: Response) {
       totalConversations,
       sourceStatsResult,
       sourceKinds,
-      pendingSequenceChunks,
+      pendingSequenceChunkStatsResult,
       unassignedTranscriptions,
       conversationsAwaitingSummary,
       jobStatsResult,
@@ -706,15 +744,21 @@ export async function apiAudioPipelineHandler(req: Request, res: Response) {
           { $sort: { count: -1 } },
         ],
       }),
-      mongo({
-        action: "count",
-        collection: "audio_chunks",
-        query: {
-          "vad.has_speech": true,
-          transcribed_at: { $eq: null },
-          transcription_sequence_id: { $exists: false },
-        },
-      }),
+      aggregatePipelineStats(
+        mongo,
+        "audio_chunks",
+        [
+          {
+            $match: {
+              "vad.has_speech": true,
+              transcribed_at: null,
+              transcription_sequence_id: { $exists: false },
+            },
+          },
+          { $count: "count" },
+        ],
+        "audio_chunks_sequence_pending_stats",
+      ),
       mongo({
         action: "count",
         collection: "transcriptions",
@@ -788,6 +832,8 @@ export async function apiAudioPipelineHandler(req: Request, res: Response) {
       }),
     ]);
 
+    const pendingSequenceChunks = pendingSequenceChunkStatsResult[0]?.count ??
+      0;
     const sourceTotals = sourceStatsResult[0] ?? {};
     const sourceFilesStats = {
       total: sourceTotals.total ?? 0,

--- a/backend/migrations/0021_audio_pipeline_stats_indexes.ts
+++ b/backend/migrations/0021_audio_pipeline_stats_indexes.ts
@@ -1,0 +1,51 @@
+import type { Db } from "mongodb";
+import { ensureIndexExists } from "@/utils/migrations.ts";
+
+export const up = async (db: Db) => {
+  console.log("Creating audio pipeline statistics indexes...");
+
+  await ensureIndexExists(
+    db,
+    "audio_chunks",
+    {
+      "vad.has_speech": 1,
+      transcribed_at: 1,
+      transcription_sequence_id: 1,
+    },
+    {
+      name: "audio_chunks_sequence_pending_stats",
+      partialFilterExpression: {
+        "vad.has_speech": true,
+        transcribed_at: null,
+      },
+    },
+  );
+
+  await ensureIndexExists(
+    db,
+    "audio_chunks",
+    {
+      original_id: 1,
+      "vad.ran_at": 1,
+      "vad.has_speech": 1,
+    },
+    { name: "audio_chunks_pipeline_source_stats" },
+  );
+
+  console.log("Created audio pipeline statistics indexes");
+};
+
+export const down = async (db: Db) => {
+  const collection = db.collection("audio_chunks");
+
+  for (
+    const name of [
+      "audio_chunks_sequence_pending_stats",
+      "audio_chunks_pipeline_source_stats",
+    ]
+  ) {
+    if (await collection.indexExists(name)) {
+      await collection.dropIndex(name);
+    }
+  }
+};

--- a/frontend/src/pages/AudioPipelinePage.tsx
+++ b/frontend/src/pages/AudioPipelinePage.tsx
@@ -223,21 +223,55 @@ export default function AudioPipelinePage() {
   );
   const [sessionLimit, setSessionLimit] = useState(DEFAULT_SESSION_LIMIT);
 
-  const { data: sessionsData, isLoading, refetch } = useQuery({
+  const {
+    data: sessionsData,
+    error: pipelineError,
+    isError,
+    isFetching,
+    isLoading,
+    refetch,
+  } = useQuery({
     queryKey: ["audio-pipeline-sessions", sessionLimit],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       // Use the new aggregated pipeline endpoint
-      const response = await fetch(
-        `${api.baseURL}/api/audio/pipeline?limit=${sessionLimit}`,
-        {
-          headers: {
-            "Authorization": `Bearer ${await api.getJWT()}`,
-          },
-        },
+      const requestController = new AbortController();
+      const cancelRequest = () => requestController.abort(signal.reason);
+      signal.addEventListener("abort", cancelRequest, { once: true });
+      const timeoutId = setTimeout(
+        () => requestController.abort(),
+        20_000,
       );
 
+      let response: Response;
+      try {
+        response = await fetch(
+          `${api.baseURL}/api/audio/pipeline?limit=${sessionLimit}`,
+          {
+            headers: {
+              "Authorization": `Bearer ${await api.getJWT()}`,
+            },
+            signal: requestController.signal,
+          },
+        );
+      } catch (error) {
+        if (requestController.signal.aborted && !signal.aborted) {
+          throw new Error(
+            "Pipeline statistics took longer than 20 seconds. Retry after the database finishes its current work.",
+          );
+        }
+        throw error;
+      } finally {
+        clearTimeout(timeoutId);
+        signal.removeEventListener("abort", cancelRequest);
+      }
+
       if (!response.ok) {
-        throw new Error("Failed to fetch pipeline data");
+        const detail = await response.text();
+        throw new Error(
+          `Failed to fetch pipeline data (${response.status})${
+            detail ? `: ${detail}` : ""
+          }`,
+        );
       }
 
       const data = await response.json();
@@ -343,7 +377,8 @@ export default function AudioPipelinePage() {
         stats,
       };
     },
-    refetchInterval: autoRefresh ? 5000 : false,
+    retry: 1,
+    refetchInterval: autoRefresh ? 30_000 : false,
   });
 
   const sessions = sessionsData?.sessions;
@@ -369,7 +404,9 @@ export default function AudioPipelinePage() {
   ) ?? [];
   const stagesWithErrors = stats?.stages?.filter((stage) => stage.errors > 0) ??
     [];
-  const pipelineHealth = !stats
+  const pipelineHealth = isError && !stats
+    ? "error"
+    : !stats
     ? "loading"
     : blockedStages.length > 0
     ? "blocked"
@@ -520,9 +557,12 @@ export default function AudioPipelinePage() {
             variant="outline"
             size="sm"
             onClick={() => refetch()}
+            disabled={isFetching}
             data-testid="refresh-btn"
           >
-            <RefreshCw className="h-4 w-4 mr-2" />
+            <RefreshCw
+              className={`h-4 w-4 mr-2 ${isFetching ? "animate-spin" : ""}`}
+            />
             Refresh
           </Button>
         </div>
@@ -531,6 +571,8 @@ export default function AudioPipelinePage() {
       <Card
         className={pipelineHealth === "loading"
           ? "border-muted bg-muted/10"
+          : pipelineHealth === "error"
+          ? "border-red-500/50 bg-red-500/5"
           : pipelineHealth === "blocked"
           ? "border-red-500/50 bg-red-500/5"
           : pipelineHealth === "processing"
@@ -544,6 +586,8 @@ export default function AudioPipelinePage() {
           <div className="flex items-start gap-3">
             {pipelineHealth === "loading"
               ? <RefreshCw className="mt-0.5 h-5 w-5 animate-spin" />
+              : pipelineHealth === "error"
+              ? <AlertCircle className="mt-0.5 h-5 w-5 text-red-600" />
               : pipelineHealth === "blocked"
               ? <PauseCircle className="mt-0.5 h-5 w-5 text-red-600" />
               : pipelineHealth === "processing"
@@ -560,6 +604,10 @@ export default function AudioPipelinePage() {
               <p className="text-sm text-muted-foreground">
                 {pipelineHealth === "loading"
                   ? "Loading source, backlog, worker, and job state."
+                  : pipelineHealth === "error"
+                  ? pipelineError instanceof Error
+                    ? pipelineError.message
+                    : "Pipeline statistics could not be loaded."
                   : blockedStages.length > 0
                   ? `${blockedStages.map((stage) => stage.label).join(", ")} ${
                     blockedStages.length === 1 ? "is" : "are"


### PR DESCRIPTION
## What changed

- add covering MongoDB indexes for pending sequence counts and recent-source VAD statistics
- apply explicit index hints with 10-second database limits and rolling-deploy fallback
- reduce automatic refresh from 5 seconds to 30 seconds
- add a 20-second frontend request timeout and a visible retryable error state

## Root cause

The pipeline endpoint counted pending sequence chunks through an index that did not cover `transcription_sequence_id`. On the live 887k-document / 61 GB `audio_chunks` collection, identical count requests accumulated for 95-448 seconds. The recent-source aggregation also fetched full chunk documents, taking over 30 seconds. Because both were inside the endpoint's `Promise.all`, the UI remained in `Pipeline loading` and hid otherwise healthy VAD progress.

## Impact

The previously multi-minute count now completes in about 126 ms, recent-source VAD aggregation in about 34 ms, and repeated full authenticated endpoint requests complete in 355-1056 ms. VAD progress and worker status are visible again without issuing a heavy request every five seconds.

## Validation

- live migration applied successfully to the local 887,292-document collection
- live authenticated endpoint: HTTP 200, 3 consecutive requests in 1056 / 393 / 355 ms
- backend Audio Pipeline tests: 5 passed
- backend migration tests: 3 passed
- frontend Vitest: 3 passed
- backend/frontend `deno check` and lint passed
- frontend production build passed
