### PR TITLE
Add cross-page audio player controls

### DIFF
--- a/frontend/src/components/GlobalAudioPlayerPopover.test.tsx
+++ b/frontend/src/components/GlobalAudioPlayerPopover.test.tsx
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { GlobalAudioPlayerPopover } from "./GlobalAudioPlayerPopover";
+import { useAudioPlayer } from "@/modules/audio/player";
+import { useSettingsStore } from "@/stores/settingsStore";
+
+function renderPlayer() {
+  return render(
+    <MemoryRouter>
+      <GlobalAudioPlayerPopover />
+    </MemoryRouter>,
+  );
+}
+
+describe("GlobalAudioPlayerPopover", () => {
+  beforeEach(() => {
+    useAudioPlayer.setState({
+      isPlaying: false,
+      currentDate: null,
+      chunks: [],
+      currentChunk: null,
+      seekTarget: null,
+      isCreatingSource: false,
+    });
+    useSettingsStore.setState({ volume: 1, playbackRate: 1 });
+  });
+
+  it("remains available before playback has been selected", () => {
+    renderPlayer();
+
+    fireEvent.click(screen.getByTestId("global-player-trigger"));
+
+    expect(screen.getByText("Now playing")).not.toBeNull();
+    expect(
+      (screen.getByRole("button", {
+        name: "Resume audio",
+      }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(screen.getByText("Ready")).not.toBeNull();
+  });
+
+  it("pauses and remains available for resume inside the popover", () => {
+    act(() => {
+      useAudioPlayer.setState({
+        isPlaying: true,
+        currentDate: new Date("2026-07-28T03:15:12.500Z"),
+      });
+    });
+    renderPlayer();
+
+    fireEvent.click(screen.getByTestId("global-player-trigger"));
+    fireEvent.click(screen.getByRole("button", { name: "Pause audio" }));
+
+    expect(useAudioPlayer.getState().isPlaying).toBe(false);
+    expect(
+      (screen.getByRole("button", {
+        name: "Resume audio",
+      }) as HTMLButtonElement).disabled,
+    ).toBe(false);
+    expect(screen.getByText("Paused")).not.toBeNull();
+  });
+});

--- a/frontend/src/components/GlobalAudioPlayerPopover.tsx
+++ b/frontend/src/components/GlobalAudioPlayerPopover.tsx
@@ -1,0 +1,225 @@
+import { Link } from "react-router-dom";
+import {
+  AudioWaveform,
+  ExternalLink,
+  Gauge,
+  Pause,
+  Play,
+  RotateCcw,
+  RotateCw,
+  Volume2,
+  VolumeX,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Slider } from "@/components/ui/slider";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useAudioPlayer } from "@/modules/audio/player";
+import { useSettingsStore } from "@/stores/settingsStore";
+
+const PLAYBACK_RATES = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3];
+
+function formatPlaybackDate(date: Date | null): string {
+  if (!date) return "Choose a time from Timeline or a transcript.";
+  return date.toLocaleDateString([], {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatPlaybackTime(date: Date | null): string {
+  if (!date) return "--:--:--";
+  return date.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+}
+
+export function GlobalAudioPlayerPopover() {
+  const {
+    chunks,
+    currentDate,
+    isCreatingSource,
+    isPlaying,
+    resetDate,
+    toggleIsPlaying,
+  } = useAudioPlayer();
+  const { playbackRate, setPlaybackRate, setVolume, volume } =
+    useSettingsStore();
+
+  const hasPlaybackPosition = currentDate !== null;
+  const isBuffering = isPlaying && (isCreatingSource || chunks.length === 0);
+  const status = !hasPlaybackPosition
+    ? "Ready"
+    : isBuffering
+    ? "Buffering"
+    : isPlaying
+    ? "Playing"
+    : "Paused";
+
+  const seekBy = (seconds: number) => {
+    if (!currentDate) return;
+    resetDate(new Date(currentDate.getTime() + seconds * 1000));
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="relative"
+          aria-label={`Open audio player${
+            hasPlaybackPosition ? `, ${status.toLowerCase()}` : ""
+          }`}
+          data-testid="global-player-trigger"
+        >
+          <AudioWaveform
+            className={isPlaying ? "text-primary" : "text-muted-foreground"}
+            size={20}
+          />
+          {hasPlaybackPosition && (
+            <span
+              className={`absolute right-1 top-1 h-2 w-2 rounded-full ring-2 ring-background ${
+                isPlaying ? "animate-pulse bg-green-500" : "bg-amber-500"
+              }`}
+            />
+          )}
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent align="end" className="w-[22rem] space-y-4 p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-sm font-semibold">Now playing</p>
+            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+              {formatPlaybackDate(currentDate)}
+            </p>
+          </div>
+          <Badge
+            variant={isPlaying ? "default" : "secondary"}
+            className="shrink-0"
+          >
+            {status}
+          </Badge>
+        </div>
+
+        <div className="rounded-lg border bg-muted/30 p-4 text-center">
+          <p className="font-mono text-2xl font-semibold tabular-nums">
+            {formatPlaybackTime(currentDate)}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Timeline position
+          </p>
+        </div>
+
+        <div className="flex items-center justify-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => seekBy(-15)}
+            disabled={!hasPlaybackPosition}
+            aria-label="Back 15 seconds"
+          >
+            <RotateCcw className="mr-1 h-4 w-4" />
+            15s
+          </Button>
+          <Button
+            size="icon"
+            className="h-11 w-11 rounded-full"
+            onClick={toggleIsPlaying}
+            disabled={!hasPlaybackPosition}
+            aria-label={isPlaying ? "Pause audio" : "Resume audio"}
+          >
+            {isPlaying
+              ? <Pause className="h-5 w-5" />
+              : <Play className="ml-0.5 h-5 w-5" />}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => seekBy(15)}
+            disabled={!hasPlaybackPosition}
+            aria-label="Forward 15 seconds"
+          >
+            15s
+            <RotateCw className="ml-1 h-4 w-4" />
+          </Button>
+        </div>
+
+        <div className="space-y-3 border-t pt-4">
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0"
+              onClick={() => setVolume(volume === 0 ? 1 : 0)}
+              aria-label={volume === 0 ? "Unmute audio" : "Mute audio"}
+            >
+              {volume === 0
+                ? <VolumeX className="h-4 w-4" />
+                : <Volume2 className="h-4 w-4" />}
+            </Button>
+            <Slider
+              value={[volume]}
+              onValueChange={([nextVolume]) => setVolume(nextVolume)}
+              min={0}
+              max={3}
+              step={0.05}
+              aria-label="Playback volume"
+            />
+            <span className="w-10 text-right text-xs tabular-nums text-muted-foreground">
+              {Math.round(volume * 100)}%
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Gauge className="ml-2 h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="text-xs text-muted-foreground">Speed</span>
+            <Select
+              value={String(playbackRate)}
+              onValueChange={(value) => setPlaybackRate(Number(value))}
+            >
+              <SelectTrigger className="ml-auto h-8 w-24">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PLAYBACK_RATES.map((rate) => (
+                  <SelectItem key={rate} value={String(rate)}>
+                    {rate}x
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <Button variant="outline" size="sm" className="w-full" asChild>
+          <Link to="/audio">
+            Open full player
+            <ExternalLink className="ml-2 h-3.5 w-3.5" />
+          </Link>
+        </Button>
+
+        <p className="text-center text-[11px] text-muted-foreground">
+          Space toggles playback from any page unless you are typing.
+        </p>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,20 +1,32 @@
 import { Link, Navigate, Outlet, useLocation } from "react-router-dom";
-import { Clock, FileText, Home, Package, Settings, MessageSquare, Activity, Mic } from "lucide-react";
+import {
+  Activity,
+  Clock,
+  FileText,
+  Home,
+  MessageSquare,
+  Mic,
+  Package,
+  Settings,
+} from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import { useSettingsStore } from "@/stores/settingsStore";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { AudioPlayer, useAudioPlayer } from "@/modules/audio/player.tsx";
-import { AudioWaveform } from "@/components/AudioWaveform";
-import { Button } from "@/components/ui/button.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { AudioPlayer } from "@/modules/audio/player.tsx";
 import { useJobsListener } from "@/hooks/useJobsListener";
 import { Badge } from "@/components/ui/badge";
 import { NotificationCenter } from "@/components/NotificationCenter";
+import { GlobalAudioPlayerPopover } from "@/components/GlobalAudioPlayerPopover";
 
 const Layout = () => {
   useTheme();
   const location = useLocation();
   const { clientId, clientSecret } = useSettingsStore();
-  const { isPlaying, setIsPlaying } = useAudioPlayer();
   const { runningCount } = useJobsListener();
 
   // Redirect to setup if no credentials
@@ -35,40 +47,44 @@ const Layout = () => {
                 <div className="flex gap-4">
                   <Link
                     to="/timeline"
-                    className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors relative ${location.pathname === "/timeline"
+                    className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors relative ${
+                      location.pathname === "/timeline"
                         ? "bg-primary text-primary-foreground"
                         : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                      }`}
+                    }`}
                   >
                     <Clock className="w-4 h-4" />
                     Timeline
                   </Link>
                   <Link
                     to="/chat"
-                    className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors relative ${location.pathname === "/chat"
+                    className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors relative ${
+                      location.pathname === "/chat"
                         ? "bg-primary text-primary-foreground"
                         : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                      }`}
+                    }`}
                   >
                     <MessageSquare className="w-4 h-4" />
                     Chat
                   </Link>
                   <Link
                     to="/objects"
-                    className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors relative ${location.pathname === "/objects"
+                    className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors relative ${
+                      location.pathname === "/objects"
                         ? "bg-primary text-primary-foreground"
                         : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                      }`}
+                    }`}
                   >
                     <Package className="w-4 h-4" />
                     Objects
                   </Link>
                   <Link
                     to="/jobs"
-                    className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors relative ${location.pathname === "/jobs"
+                    className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors relative ${
+                      location.pathname === "/jobs"
                         ? "bg-primary text-primary-foreground"
                         : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                      }`}
+                    }`}
                   >
                     <Activity className="w-4 h-4" />
                     Jobs
@@ -83,20 +99,22 @@ const Layout = () => {
                   </Link>
                   <Link
                     to="/summaries"
-                    className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors relative ${location.pathname.startsWith("/summaries")
+                    className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors relative ${
+                      location.pathname.startsWith("/summaries")
                         ? "bg-primary text-primary-foreground"
                         : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                      }`}
+                    }`}
                   >
                     <FileText className="w-4 h-4" />
                     AI History
                   </Link>
                   <Link
                     to="/audio/pipeline"
-                    className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors relative ${location.pathname === "/audio/pipeline"
+                    className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors relative ${
+                      location.pathname === "/audio/pipeline"
                         ? "bg-primary text-primary-foreground"
                         : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                      }`}
+                    }`}
                     data-testid="nav-pipeline"
                   >
                     <Mic className="w-4 h-4" />
@@ -104,10 +122,11 @@ const Layout = () => {
                   </Link>
                   <Link
                     to="/settings"
-                    className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors relative ${location.pathname === "/settings"
+                    className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors relative ${
+                      location.pathname === "/settings"
                         ? "bg-primary text-primary-foreground"
                         : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                      }`}
+                    }`}
                   >
                     <Settings className="w-4 h-4" />
                     Settings
@@ -116,16 +135,7 @@ const Layout = () => {
               </div>
               <div className="flex items-center gap-2">
                 <NotificationCenter />
-                {isPlaying && (
-                  <Link to="/audio">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                    >
-                      <AudioWaveform size={20} />
-                    </Button>
-                  </Link>
-                )}
+                <GlobalAudioPlayerPopover />
               </div>
             </div>
           </div>

--- a/frontend/src/components/timeline/TimelinePlayerControls.tsx
+++ b/frontend/src/components/timeline/TimelinePlayerControls.tsx
@@ -15,7 +15,6 @@ import {
 } from "@/components/ui/tooltip";
 import { useAudioPlayer } from "@/modules/audio/player";
 import { useSettingsStore } from "@/stores/settingsStore";
-import { useEffect } from "react";
 
 const PLAYBACK_RATES = [0.5, 0.75, 1, 1.25, 1.5, 2];
 
@@ -40,29 +39,8 @@ function formatDate(date: Date | null): string {
 
 export function TimelinePlayerControls() {
   const { isPlaying, toggleIsPlaying, currentDate } = useAudioPlayer();
-  const { volume, setVolume, playbackRate, setPlaybackRate } = useSettingsStore();
-
-  // Keyboard shortcut for play/pause (Space)
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      // Don't trigger if user is typing in an input
-      if (
-        event.target instanceof HTMLInputElement ||
-        event.target instanceof HTMLTextAreaElement
-      ) {
-        return;
-      }
-      if (event.code === "Space") {
-        event.preventDefault();
-        toggleIsPlaying();
-      }
-    };
-
-    globalThis.addEventListener("keydown", handleKeyDown);
-    return () => {
-      globalThis.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [toggleIsPlaying]);
+  const { volume, setVolume, playbackRate, setPlaybackRate } =
+    useSettingsStore();
 
   const isMuted = volume === 0;
 
@@ -77,11 +55,9 @@ export function TimelinePlayerControls() {
             className="h-8 w-8"
             onClick={() => toggleIsPlaying()}
           >
-            {isPlaying ? (
-              <Pause className="h-4 w-4" />
-            ) : (
-              <Play className="h-4 w-4" />
-            )}
+            {isPlaying
+              ? <Pause className="h-4 w-4" />
+              : <Play className="h-4 w-4" />}
           </Button>
         </TooltipTrigger>
         <TooltipContent>
@@ -112,11 +88,9 @@ export function TimelinePlayerControls() {
               className="h-8 w-8"
               onClick={() => setVolume(isMuted ? 1 : 0)}
             >
-              {isMuted ? (
-                <VolumeX className="h-4 w-4" />
-              ) : (
-                <Volume2 className="h-4 w-4" />
-              )}
+              {isMuted
+                ? <VolumeX className="h-4 w-4" />
+                : <Volume2 className="h-4 w-4" />}
             </Button>
           </TooltipTrigger>
           <TooltipContent>

--- a/frontend/src/modules/audio/PlayPauseButton.tsx
+++ b/frontend/src/modules/audio/PlayPauseButton.tsx
@@ -1,24 +1,9 @@
-import { useEffect } from "react";
 import { Pause, Play } from "lucide-react";
 import { Button } from "@/components/ui/button.tsx";
 import { useAudioPlayer } from "./player.tsx";
 
 export const PlayPauseButton = () => {
   const { isPlaying, toggleIsPlaying } = useAudioPlayer();
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.code === "Space") {
-        event.preventDefault();
-        toggleIsPlaying();
-      }
-    };
-
-    globalThis.addEventListener("keydown", handleKeyDown);
-    return () => {
-      globalThis.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [toggleIsPlaying]);
 
   return (
     <Button onClick={() => toggleIsPlaying()}>

--- a/frontend/src/modules/audio/player.test.ts
+++ b/frontend/src/modules/audio/player.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { act } from "@testing-library/react";
+import { type Chunk, useAudioPlayer } from "./player";
+
+function chunk(id: string, start: Date): Chunk {
+  return { _id: id, start, buffer: {} as AudioBuffer };
+}
+
+describe("audio player playback state", () => {
+  beforeEach(() => {
+    useAudioPlayer.setState({
+      isPlaying: false,
+      currentDate: null,
+      startDate: null,
+      seekTarget: null,
+      seekGeneration: 0,
+      chunks: [],
+      currentChunk: null,
+      sourceNode: null,
+      baselineStartDate: null,
+      baselineStartCtxTime: null,
+    });
+  });
+
+  it("preserves the current chunk and exact position when paused", () => {
+    const currentDate = new Date("2026-07-28T03:15:12.500Z");
+    const activeChunk = chunk(
+      "active",
+      new Date("2026-07-28T03:15:10.000Z"),
+    );
+    const nextChunk = chunk("next", new Date("2026-07-28T03:15:20.000Z"));
+
+    useAudioPlayer.setState({
+      isPlaying: true,
+      currentDate,
+      currentChunk: activeChunk,
+      chunks: [nextChunk],
+      baselineStartDate: currentDate,
+      baselineStartCtxTime: 10,
+    });
+
+    act(() => useAudioPlayer.getState().setIsPlaying(false));
+
+    const state = useAudioPlayer.getState();
+    expect(state.isPlaying).toBe(false);
+    expect(state.seekTarget).toEqual(currentDate);
+    expect(state.currentChunk).toBeNull();
+    expect(state.chunks.map((item) => item._id)).toEqual(["active", "next"]);
+    expect(state.baselineStartDate).toBeNull();
+    expect(state.baselineStartCtxTime).toBeNull();
+  });
+
+  it("resumes without discarding the saved playback position", () => {
+    const currentDate = new Date("2026-07-28T03:15:12.500Z");
+    useAudioPlayer.setState({
+      isPlaying: false,
+      currentDate,
+      seekTarget: currentDate,
+    });
+
+    act(() => useAudioPlayer.getState().toggleIsPlaying());
+
+    expect(useAudioPlayer.getState().isPlaying).toBe(true);
+    expect(useAudioPlayer.getState().seekTarget).toEqual(currentDate);
+  });
+});

--- a/frontend/src/modules/audio/player.tsx
+++ b/frontend/src/modules/audio/player.tsx
@@ -43,7 +43,27 @@ export interface DateStore {
   ) => void;
 }
 
-export const useAudioPlayer = create<DateStore>((set) => ({
+function pausedPlayerState(state: DateStore): Partial<DateStore> {
+  if (!state.currentDate) return { isPlaying: false };
+
+  const bufferedChunks = state.currentChunk
+    ? [
+      state.currentChunk,
+      ...state.chunks.filter((chunk) => chunk._id !== state.currentChunk?._id),
+    ]
+    : state.chunks;
+
+  return {
+    isPlaying: false,
+    chunks: bufferedChunks,
+    currentChunk: null,
+    seekTarget: state.currentDate,
+    baselineStartDate: null,
+    baselineStartCtxTime: null,
+  };
+}
+
+export const useAudioPlayer = create<DateStore>((set, get) => ({
   currentDate: null,
   startDate: null,
   seekTarget: null,
@@ -58,8 +78,9 @@ export const useAudioPlayer = create<DateStore>((set) => ({
   rafId: null,
   baselineStartDate: null,
   baselineStartCtxTime: null,
-  setIsPlaying: (isPlaying: boolean) => set({ isPlaying }),
-  toggleIsPlaying: () => set((state) => ({ isPlaying: !state.isPlaying })),
+  setIsPlaying: (isPlaying: boolean) =>
+    set((state) => isPlaying ? { isPlaying: true } : pausedPlayerState(state)),
+  toggleIsPlaying: () => get().setIsPlaying(!get().isPlaying),
   updateDate: (date: Date) => set({ currentDate: date }),
   resetDate(date: Date | null) {
     const state = useAudioPlayer.getState();
@@ -88,7 +109,7 @@ export const useAudioPlayer = create<DateStore>((set) => ({
       baselineStartCtxTime: null,
       sourceNode: null,
       rafId: null,
-      isCreatingSource: false
+      isCreatingSource: false,
     });
   },
   appendChunks(chunks: Chunk[], generation: number) {
@@ -161,12 +182,31 @@ export const AudioPlayer: React.FC = () => {
     setSourceNode,
     sourceNode,
     startDate,
+    toggleIsPlaying,
     updateDate,
   } = useAudioPlayer();
-  
+
   // Get volume and playbackRate from settings store
   const { volume, playbackRate } = useSettingsStore();
   const preloadLimit = 20; // Number of segments to preload
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target;
+      const isTyping = target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target instanceof HTMLSelectElement ||
+        (target instanceof HTMLElement && target.isContentEditable);
+
+      if (event.code !== "Space" || event.repeat || isTyping) return;
+
+      event.preventDefault();
+      toggleIsPlaying();
+    };
+
+    globalThis.addEventListener("keydown", handleKeyDown);
+    return () => globalThis.removeEventListener("keydown", handleKeyDown);
+  }, [toggleIsPlaying]);
 
   useEffect(() => {
     if (isPlaying && !audioContext) {
@@ -176,7 +216,7 @@ export const AudioPlayer: React.FC = () => {
     }
   }, [isPlaying, audioContext]);
 
-  const loadingRef = useRef(false)
+  const loadingRef = useRef(false);
 
   const fetchAndDecodeBuffers = async () => {
     if (loadingRef.current) return;
@@ -189,7 +229,7 @@ export const AudioPlayer: React.FC = () => {
     if (!start) return;
 
     try {
-      loadingRef.current = true
+      loadingRef.current = true;
       const lastId = prev ? prev._id : null;
       const resp = await apiClient.get(
         `/data/audio?start=${start.getTime()}&limit=${preloadLimit}${
@@ -220,7 +260,7 @@ export const AudioPlayer: React.FC = () => {
         }
       }
     } finally {
-      loadingRef.current = false
+      loadingRef.current = false;
     }
   };
 
@@ -240,9 +280,12 @@ export const AudioPlayer: React.FC = () => {
   }, [volume, gainNode]);
 
   useEffect(() => {
-    if (sourceNode && audioContext && sourceNode.playbackRate.value !== playbackRate) {
+    if (
+      sourceNode && audioContext &&
+      sourceNode.playbackRate.value !== playbackRate
+    ) {
       sourceNode.playbackRate.value = playbackRate;
-      
+
       // if (isPlaying && currentDate && audioContext) {
       //   setBaselines(currentDate, audioContext.currentTime);
       // }
@@ -265,7 +308,8 @@ export const AudioPlayer: React.FC = () => {
     }
 
     if (seekTarget) {
-      const chunkEndTime = chunk.start.getTime() + (chunk.buffer.duration * 1000);
+      const chunkEndTime = chunk.start.getTime() +
+        (chunk.buffer.duration * 1000);
       while (chunk && seekTarget.getTime() > chunkEndTime) {
         chunk = await popChunk();
         if (!chunk) {
@@ -342,11 +386,14 @@ export const AudioPlayer: React.FC = () => {
     }
 
     const tick = () => {
-      const { baselineStartDate, baselineStartCtxTime } = useAudioPlayer.getState();
+      const { baselineStartDate, baselineStartCtxTime } = useAudioPlayer
+        .getState();
       const currentPlaybackRate = useSettingsStore.getState().playbackRate;
       if (baselineStartDate && baselineStartCtxTime !== null) {
         const elapsed = audioContext.currentTime - baselineStartCtxTime;
-        const newDate = new Date(baselineStartDate.getTime() + elapsed * currentPlaybackRate * 1000);
+        const newDate = new Date(
+          baselineStartDate.getTime() + elapsed * currentPlaybackRate * 1000,
+        );
         updateDate(newDate);
       }
       frameId = requestAnimationFrame(tick);


### PR DESCRIPTION
## What changed

- replace the header route-only audio icon with an always-available player popover
- expose play/pause, 15-second seek, volume, mute, speed, current timeline time, and playback status without leaving the current page
- preserve the exact current chunk and offset when pausing so resume does not skip forward
- centralize the Space shortcut in the single global audio engine and ignore typing targets
- keep local waveform/diarization preview players independent from timeline playback

## Why

The existing global player already survived route changes, but its header control appeared only while audio was playing and navigated to a separate page. Pausing therefore removed the easiest resume control, and stopping the active WebAudio source could advance to the next chunk.

## Validation

- `deno check` on all 7 changed/new frontend files
- `deno lint` on all 7 changed/new frontend files
- `vitest`: 4/4 new component and playback-state tests passed
- `deno task build` passed (7,981 modules transformed)

A broader existing `TimelinePage.test.tsx` remains blocked before the tested UI is reached by the repository's current `myceliasdk/zod-json-schema.ts` / Zod setup (`Cannot set properties of undefined (setting 'toJSONSchema')`). Browser smoke was additionally limited by one profile lacking credentials and another local nginx profile returning 502.