### PR TITLE
Add timeline time zone context

### DIFF
--- a/backend/app/lib/resources/registry.ts
+++ b/backend/app/lib/resources/registry.ts
@@ -13,6 +13,7 @@ import { MessengerResource } from "@/lib/messenger/resource.server.ts";
 import { SearchResource } from "@/lib/search/resource.server.ts";
 import { DocsResource } from "@/lib/docs/resource.server.ts";
 import { ConfigResource } from "@/lib/config/resource.server.ts";
+import { TimelineTimeZonesResource } from "@/lib/timezones/resource.server.ts";
 
 const resources = [
   MongoResource,
@@ -28,6 +29,7 @@ const resources = [
   SearchResource,
   DocsResource,
   ConfigResource,
+  TimelineTimeZonesResource,
 ];
 
 export async function setupResources(): Promise<void> {

--- a/backend/app/lib/timezones/resource.server.test.ts
+++ b/backend/app/lib/timezones/resource.server.test.ts
@@ -1,0 +1,42 @@
+import { expect } from "@std/expect";
+import {
+  isValidTimeZone,
+  timelineTimeZonesRequestSchema,
+} from "./resource.server.ts";
+
+Deno.test("timeline time zone validation accepts IANA zones", () => {
+  expect(isValidTimeZone("Europe/Paris")).toBe(true);
+  expect(isValidTimeZone("Asia/Tbilisi")).toBe(true);
+  expect(isValidTimeZone("Not/A_Time_Zone")).toBe(false);
+});
+
+Deno.test("timeline time zone periods require an increasing range", () => {
+  const result = timelineTimeZonesRequestSchema.safeParse({
+    action: "create",
+    period: {
+      start: "2026-07-28T12:00:00.000Z",
+      end: "2026-07-28T11:00:00.000Z",
+      timeZone: "Europe/Paris",
+    },
+  });
+
+  expect(result.success).toBe(false);
+});
+
+Deno.test("timeline time zone periods preserve import provenance", () => {
+  const result = timelineTimeZonesRequestSchema.parse({
+    action: "create",
+    period: {
+      start: "2026-07-28T10:00:00.000Z",
+      end: "2026-07-28T11:00:00.000Z",
+      timeZone: "Europe/Paris",
+      location: { name: "Metz" },
+      source: "metadata",
+      metadata: { provider: "photo-exif" },
+    },
+  });
+
+  if (result.action !== "create") throw new Error("Expected create action");
+  expect(result.period.source).toBe("metadata");
+  expect(result.period.location?.name).toBe("Metz");
+});

--- a/backend/app/lib/timezones/resource.server.ts
+++ b/backend/app/lib/timezones/resource.server.ts
@@ -1,0 +1,141 @@
+import { ObjectId } from "bson";
+import { z } from "zod";
+import { type Auth } from "@/lib/auth/core.server.ts";
+import { type Resource } from "@/lib/auth/resources.ts";
+import { getMongoResource } from "@/lib/mongo/core.server.ts";
+import { zDateOrString } from "@myceliasdk/zod-json-schema.ts";
+
+export function isValidTimeZone(value: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: value }).format();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const timeZoneSchema = z.string().min(1).refine(isValidTimeZone, {
+  message: "Expected a valid IANA time zone (for example, Europe/Paris)",
+});
+
+const locationSchema = z.object({
+  name: z.string().trim().min(1).optional(),
+  latitude: z.number().min(-90).max(90).optional(),
+  longitude: z.number().min(-180).max(180).optional(),
+}).refine(
+  (value) => (value.latitude === undefined) === (value.longitude === undefined),
+  { message: "Latitude and longitude must be provided together" },
+);
+
+const periodInputSchema = z.object({
+  start: zDateOrString(),
+  end: zDateOrString(),
+  timeZone: timeZoneSchema,
+  location: locationSchema.optional(),
+  source: z.enum(["manual", "import", "metadata"]).default("manual"),
+  metadata: z.record(z.string(), z.any()).optional(),
+}).refine((value) => value.end.getTime() > value.start.getTime(), {
+  message: "Time zone period end must be after its start",
+  path: ["end"],
+});
+
+const listSchema = z.object({
+  action: z.literal("list"),
+  start: zDateOrString().optional(),
+  end: zDateOrString().optional(),
+});
+
+const createSchema = z.object({
+  action: z.literal("create"),
+  period: periodInputSchema,
+});
+
+const deleteSchema = z.object({
+  action: z.literal("delete"),
+  id: z.string().refine(ObjectId.isValid, "Invalid time zone period id"),
+});
+
+export const timelineTimeZonesRequestSchema = z.discriminatedUnion("action", [
+  listSchema,
+  createSchema,
+  deleteSchema,
+]);
+
+export type TimelineTimeZonesRequest = z.input<
+  typeof timelineTimeZonesRequestSchema
+>;
+export type TimelineTimeZonesResponse = unknown;
+
+const COLLECTION = "timeline_timezone_periods";
+
+export class TimelineTimeZonesResource
+  implements Resource<TimelineTimeZonesRequest, TimelineTimeZonesResponse> {
+  code = "timeline-timezones";
+  description =
+    "Store time zone and optional geographic context for timeline periods";
+  schemas = {
+    request: timelineTimeZonesRequestSchema,
+    response: z.any(),
+  };
+
+  extractActions(input: TimelineTimeZonesRequest) {
+    return [{
+      path: ["timeline-timezones"],
+      actions: [input.action],
+    }];
+  }
+
+  async use(
+    rawInput: TimelineTimeZonesRequest,
+    auth: Auth,
+  ): Promise<TimelineTimeZonesResponse> {
+    const input = timelineTimeZonesRequestSchema.parse(rawInput);
+    const mongo = await getMongoResource(auth);
+
+    switch (input.action) {
+      case "list": {
+        const query: Record<string, unknown> = {};
+        if (input.start && input.end) {
+          query.start = { $lt: input.end };
+          query.end = { $gt: input.start };
+        } else if (input.start) {
+          query.end = { $gt: input.start };
+        } else if (input.end) {
+          query.start = { $lt: input.end };
+        }
+
+        return await mongo({
+          action: "find",
+          collection: COLLECTION,
+          query,
+          options: { sort: { start: 1, createdAt: 1 } },
+        });
+      }
+
+      case "create": {
+        const now = new Date();
+        const doc = {
+          ...input.period,
+          createdAt: now,
+          updatedAt: now,
+          createdBy: auth.principal,
+        };
+        const result = await mongo({
+          action: "insertOne",
+          collection: COLLECTION,
+          doc,
+        });
+        return { ...doc, _id: result.insertedId };
+      }
+
+      case "delete": {
+        await mongo({
+          action: "deleteOne",
+          collection: COLLECTION,
+          query: { _id: new ObjectId(input.id) },
+        });
+        return { success: true };
+      }
+    }
+  }
+}

--- a/backend/migrations/0022_timeline_timezone_periods.ts
+++ b/backend/migrations/0022_timeline_timezone_periods.ts
@@ -1,0 +1,35 @@
+import type { Db } from "mongodb";
+import {
+  ensureCollectionExists,
+  ensureIndexExists,
+} from "@/utils/migrations.ts";
+
+const COLLECTION = "timeline_timezone_periods";
+
+export async function up(db: Db): Promise<void> {
+  await ensureCollectionExists(db, COLLECTION);
+  await ensureIndexExists(
+    db,
+    COLLECTION,
+    { start: 1, end: 1 },
+    { name: "timeline_timezone_period_range" },
+  );
+  await ensureIndexExists(
+    db,
+    COLLECTION,
+    { createdAt: 1 },
+    { name: "timeline_timezone_period_created" },
+  );
+}
+
+export async function down(db: Db): Promise<void> {
+  const collection = db.collection(COLLECTION);
+  for (
+    const name of [
+      "timeline_timezone_period_range",
+      "timeline_timezone_period_created",
+    ]
+  ) {
+    if (await collection.indexExists(name)) await collection.dropIndex(name);
+  }
+}

--- a/frontend/src/components/TimeZoneSelect.tsx
+++ b/frontend/src/components/TimeZoneSelect.tsx
@@ -1,0 +1,46 @@
+import { useMemo } from "react";
+import {
+  BROWSER_TIME_ZONE,
+  getBrowserTimeZone,
+  getSupportedTimeZones,
+} from "@/lib/timeZones";
+
+interface TimeZoneSelectProps {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  includeBrowser?: boolean;
+  className?: string;
+  disabled?: boolean;
+}
+
+export function TimeZoneSelect({
+  id,
+  value,
+  onChange,
+  includeBrowser = false,
+  className = "",
+  disabled = false,
+}: TimeZoneSelectProps) {
+  const timeZones = useMemo(getSupportedTimeZones, []);
+  const browserTimeZone = getBrowserTimeZone();
+
+  return (
+    <select
+      id={id}
+      value={value}
+      disabled={disabled}
+      onChange={(event) => onChange(event.target.value)}
+      className={`flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+    >
+      {includeBrowser && (
+        <option value={BROWSER_TIME_ZONE}>
+          Current device ({browserTimeZone})
+        </option>
+      )}
+      {timeZones.map((timeZone) => (
+        <option key={timeZone} value={timeZone}>{timeZone}</option>
+      ))}
+    </select>
+  );
+}

--- a/frontend/src/components/timeline/MultiTrackTimeline.tsx
+++ b/frontend/src/components/timeline/MultiTrackTimeline.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, memo } from "react";
+import React, { memo, useMemo } from "react";
 import { useTimelineRange } from "@/stores/timelineRange";
 import { useHistogramItems } from "@/modules/histogram/useHistogramItems";
 import { useTrackVisibilityStore } from "@/stores/trackVisibilityStore";
@@ -7,20 +7,21 @@ import { ObjectsLayer } from "@/modules/objects";
 import { ProcessingLayer } from "@/modules/histogram/ProcessingLayer";
 import { AudioLayer } from "@/modules/audio/index";
 import {
-  VoiceDetectionTrack,
-  DataPresenceTrack,
-  TranscriptionsTrack,
-  AudioChunksTrack,
-  DiarizationsTrack,
-  VOICE_DETECTION_CONFIG,
-  DATA_PRESENCE_CONFIG,
-  TRANSCRIPTIONS_CONFIG,
   AUDIO_CHUNKS_CONFIG,
+  AudioChunksTrack,
+  DATA_PRESENCE_CONFIG,
+  DataPresenceTrack,
   DIARIZATIONS_CONFIG,
+  DiarizationsTrack,
+  TRANSCRIPTIONS_CONFIG,
+  TranscriptionsTrack,
+  VOICE_DETECTION_CONFIG,
+  VoiceDetectionTrack,
 } from "./tracks";
 import { TrackHeader } from "./tracks/TrackHeader";
 import type { TrackId } from "@/types/tracks";
 import type { useTimeline } from "@/hooks/useTimeline";
+import { TimeZoneContextTrack } from "./TimeZoneContextTrack";
 
 // Pre-create layer instances (these are stable references)
 const TIME_LAYER = TimeLayer();
@@ -79,7 +80,7 @@ export const MultiTrackTimeline = memo(function MultiTrackTimeline({
 
   const visibleHistogramTracks = useMemo(
     () => HISTOGRAM_TRACK_IDS.filter((id) => visibleTracks.includes(id)),
-    [visibleTracks]
+    [visibleTracks],
   );
 
   const showObjects = visibleTracks.includes("objects");
@@ -101,6 +102,12 @@ export const MultiTrackTimeline = memo(function MultiTrackTimeline({
           width={width}
         />
 
+        <TimeZoneContextTrack
+          scale={timeScale}
+          transform={transform}
+          width={width}
+        />
+
         {/* Data tracks */}
         {visibleHistogramTracks.map((trackId) => {
           const TrackComponent = TRACK_COMPONENTS[trackId];
@@ -110,8 +117,18 @@ export const MultiTrackTimeline = memo(function MultiTrackTimeline({
           if (!TrackComponent) return null;
 
           return (
-            <div key={trackId} className="relative border-b border-border/30 last:border-b-0">
-              <TrackHeader config={{ ...config, id: trackId, defaultVisible: true, defaultHeight: height }} />
+            <div
+              key={trackId}
+              className="relative border-b border-border/30 last:border-b-0"
+            >
+              <TrackHeader
+                config={{
+                  ...config,
+                  id: trackId,
+                  defaultVisible: true,
+                  defaultHeight: height,
+                }}
+              />
               <TrackComponent
                 scale={timeScale}
                 transform={transform}

--- a/frontend/src/components/timeline/TimeZoneContextTrack.tsx
+++ b/frontend/src/components/timeline/TimeZoneContextTrack.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+import type * as d3 from "d3";
+import { useTimelineTimeZone } from "@/hooks/useTimelineTimeZone";
+import { getShortTimeZoneName } from "@/lib/timeZones";
+
+interface TimeZoneContextTrackProps {
+  scale: d3.ScaleTime<number, number>;
+  transform: d3.ZoomTransform;
+  width: number;
+}
+
+export function TimeZoneContextTrack({
+  scale,
+  transform,
+  width,
+}: TimeZoneContextTrackProps) {
+  const { periods } = useTimelineTimeZone();
+  const rendered = useMemo(() => {
+    const rescaled = transform.rescaleX(scale);
+    const [domainStart, domainEnd] = rescaled.domain();
+    return periods.flatMap((period) => {
+      const start = new Date(period.start);
+      const end = new Date(period.end);
+      if (end <= domainStart || start >= domainEnd) return [];
+      const left = Math.max(0, rescaled(start));
+      const right = Math.min(width, rescaled(end));
+      return [{
+        ...period,
+        left,
+        width: Math.max(1, right - left),
+        start,
+      }];
+    });
+  }, [periods, scale, transform, width]);
+
+  if (rendered.length === 0) return null;
+
+  return (
+    <div className="relative h-7 overflow-hidden rounded-sm border-y bg-muted/20">
+      <div className="absolute left-2 top-1 z-10 text-[10px] font-medium text-muted-foreground">
+        Time zones
+      </div>
+      {rendered.map((period) => (
+        <div
+          key={typeof period._id === "string"
+            ? period._id
+            : period._id.toString()}
+          className="absolute inset-y-0 overflow-hidden border-x border-primary/30 bg-primary/10 px-1 text-[10px] leading-7 text-primary"
+          style={{ left: period.left, width: period.width }}
+          title={`${
+            period.location?.name ? `${period.location.name} · ` : ""
+          }${period.timeZone}`}
+        >
+          <span className="whitespace-nowrap">
+            {period.location?.name ? `${period.location.name} · ` : ""}
+            {period.timeZone}{" "}
+            ({getShortTimeZoneName(period.start, period.timeZone)})
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/timeline/TimelineHeader.tsx
+++ b/frontend/src/components/timeline/TimelineHeader.tsx
@@ -2,6 +2,7 @@ import { TimelineToolbar } from "./TimelineToolbar";
 import { TimelineSelectionActions } from "./TimelineSelectionActions";
 import { TrackVisibilityButton } from "./controls/TrackVisibilityPanel";
 import { TimelinePlayerControls } from "./TimelinePlayerControls";
+import { TimelineTimeZoneControl } from "./TimelineTimeZoneControl";
 
 interface TimelineHeaderProps {
   hasTimeSelection: boolean;
@@ -43,6 +44,10 @@ export function TimelineHeader({
             onClearSelection={onClearTimeSelection}
           />
         )}
+        <TimelineTimeZoneControl
+          selectionStart={timeSelectionStart}
+          selectionEnd={timeSelectionEnd}
+        />
         <TimelineToolbar
           onZoomToFit={onZoomToFit}
           onTimeRangeSelect={onTimeRangeSelect}

--- a/frontend/src/components/timeline/TimelineTimeZoneControl.tsx
+++ b/frontend/src/components/timeline/TimelineTimeZoneControl.tsx
@@ -1,0 +1,214 @@
+import { useMemo, useState } from "react";
+import { Clock3, Loader2, MapPin, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { TimeZoneSelect } from "@/components/TimeZoneSelect";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useTimelineTimeZoneStore } from "@/stores/timelineTimeZoneStore";
+import { useTimelineTimeZone } from "@/hooks/useTimelineTimeZone";
+import {
+  getPeriodId,
+  getShortTimeZoneName,
+  type TimelineTimeZonePeriod,
+} from "@/lib/timeZones";
+
+interface TimelineTimeZoneControlProps {
+  selectionStart?: Date;
+  selectionEnd?: Date;
+}
+
+function describePeriod(period: TimelineTimeZonePeriod) {
+  const start = new Date(period.start).toLocaleDateString(undefined, {
+    timeZone: period.timeZone,
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+  const end = new Date(period.end).toLocaleDateString(undefined, {
+    timeZone: period.timeZone,
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+  return `${start} – ${end}`;
+}
+
+export function TimelineTimeZoneControl({
+  selectionStart,
+  selectionEnd,
+}: TimelineTimeZoneControlProps) {
+  const mode = useSettingsStore((state) => state.timelineTimeZoneMode);
+  const override = useSettingsStore((state) => state.timelineTimeZoneOverride);
+  const setMode = useSettingsStore((state) => state.setTimelineTimeZoneMode);
+  const setOverride = useSettingsStore(
+    (state) => state.setTimelineTimeZoneOverride,
+  );
+  const { activeTimeZone, browserTimeZone, periods } = useTimelineTimeZone();
+  const createPeriod = useTimelineTimeZoneStore((state) => state.createPeriod);
+  const deletePeriod = useTimelineTimeZoneStore((state) => state.deletePeriod);
+  const saving = useTimelineTimeZoneStore((state) => state.saving);
+  const error = useTimelineTimeZoneStore((state) => state.error);
+  const [periodTimeZone, setPeriodTimeZone] = useState(activeTimeZone);
+  const [location, setLocation] = useState("");
+  const [saved, setSaved] = useState(false);
+
+  const selectedPeriods = useMemo(() => {
+    if (!selectionStart || !selectionEnd) return periods;
+    return periods.filter((period) =>
+      new Date(period.start) < selectionEnd &&
+      new Date(period.end) > selectionStart
+    );
+  }, [periods, selectionEnd, selectionStart]);
+
+  const displayValue = mode === "fixed" ? `fixed:${override}` : mode;
+
+  const handleDisplayChange = (value: string) => {
+    if (value === "contextual" || value === "browser") {
+      setMode(value);
+      return;
+    }
+    setOverride(value.slice("fixed:".length));
+    setMode("fixed");
+  };
+
+  const handleSave = async () => {
+    if (!selectionStart || !selectionEnd) return;
+    try {
+      await createPeriod({
+        start: selectionStart,
+        end: selectionEnd,
+        timeZone: periodTimeZone,
+        location: location.trim() ? { name: location.trim() } : undefined,
+        source: "manual",
+      });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch {
+      // The store exposes the request error in this popover.
+    }
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-2">
+          <Clock3 className="h-4 w-4" />
+          <span className="hidden lg:inline">{activeTimeZone}</span>
+          <span className="text-xs text-muted-foreground">
+            {getShortTimeZoneName(new Date(), activeTimeZone)}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-[380px] space-y-5">
+        <div className="space-y-1">
+          <h3 className="font-medium">Timeline time zone</h3>
+          <p className="text-xs text-muted-foreground">
+            Change only how instants are displayed; recorded timestamps remain
+            unchanged.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="timeline-time-zone-mode">Display as</Label>
+          <select
+            id="timeline-time-zone-mode"
+            value={displayValue}
+            onChange={(event) => handleDisplayChange(event.target.value)}
+            className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm"
+          >
+            <option value="contextual">Recorded period, then default</option>
+            <option value="browser">Current device ({browserTimeZone})</option>
+            <option value={`fixed:${override}`}>Specific: {override}</option>
+          </select>
+          {mode === "fixed" && (
+            <TimeZoneSelect value={override} onChange={setOverride} />
+          )}
+        </div>
+
+        <div className="border-t pt-4 space-y-3">
+          <div>
+            <Label>Save time zone for selected period</Label>
+            <p className="text-xs text-muted-foreground mt-1">
+              {selectionStart && selectionEnd
+                ? "This context is stored in Mycelia and used by contextual display."
+                : "Select a range on the time axis first."}
+            </p>
+          </div>
+          <TimeZoneSelect
+            value={periodTimeZone}
+            onChange={setPeriodTimeZone}
+            disabled={!selectionStart || !selectionEnd}
+          />
+          <div className="relative">
+            <MapPin className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              value={location}
+              onChange={(event) => setLocation(event.target.value)}
+              disabled={!selectionStart || !selectionEnd}
+              placeholder="Place (optional), e.g. Metz"
+              className="pl-9"
+            />
+          </div>
+          <Button
+            size="sm"
+            className="w-full"
+            disabled={!selectionStart || !selectionEnd || saving}
+            onClick={handleSave}
+          >
+            {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {saved ? "Saved" : "Save period"}
+          </Button>
+          {error && <p className="text-xs text-destructive">{error}</p>}
+        </div>
+
+        {selectedPeriods.length > 0 && (
+          <div className="border-t pt-4 space-y-2">
+            <Label>
+              Saved periods {selectionStart ? "in selection" : "in view"}
+            </Label>
+            <div className="max-h-40 overflow-y-auto space-y-2">
+              {selectedPeriods.map((period) => (
+                <div
+                  key={getPeriodId(period)}
+                  className="flex items-start justify-between gap-2 rounded border p-2 text-xs"
+                >
+                  <div className="min-w-0">
+                    <div className="font-medium truncate">
+                      {period.location?.name
+                        ? `${period.location.name} · `
+                        : ""}
+                      {period.timeZone}
+                    </div>
+                    <div className="text-muted-foreground">
+                      {describePeriod(period)}
+                    </div>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 shrink-0"
+                    aria-label={`Delete ${period.timeZone} period`}
+                    disabled={saving}
+                    onClick={() => {
+                      void deletePeriod(getPeriodId(period)).catch(() => {
+                        // The store exposes the request error in this popover.
+                      });
+                    }}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/hooks/useTimelineTimeZone.ts
+++ b/frontend/src/hooks/useTimelineTimeZone.ts
@@ -1,0 +1,48 @@
+import { useCallback, useMemo } from "react";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useTimelineTimeZoneStore } from "@/stores/timelineTimeZoneStore";
+import {
+  findTimeZonePeriod,
+  getBrowserTimeZone,
+  resolveDefaultTimeZone,
+} from "@/lib/timeZones";
+
+export function useTimelineTimeZone() {
+  const defaultTimeZone = useSettingsStore((state) => state.defaultTimeZone);
+  const mode = useSettingsStore((state) => state.timelineTimeZoneMode);
+  const override = useSettingsStore(
+    (state) => state.timelineTimeZoneOverride,
+  );
+  const periods = useTimelineTimeZoneStore((state) => state.periods);
+  const browserTimeZone = getBrowserTimeZone();
+  const fallbackTimeZone = resolveDefaultTimeZone(defaultTimeZone);
+
+  const fixedTimeZone = mode === "browser"
+    ? browserTimeZone
+    : mode === "fixed"
+    ? override
+    : fallbackTimeZone;
+
+  const resolveTimeZone = useCallback(
+    (instant: Date) => {
+      if (mode !== "contextual") return fixedTimeZone;
+      return findTimeZonePeriod(periods, instant)?.timeZone ?? fallbackTimeZone;
+    },
+    [fallbackTimeZone, fixedTimeZone, mode, periods],
+  );
+
+  const activeTimeZone = useMemo(
+    () => resolveTimeZone(new Date()),
+    [resolveTimeZone],
+  );
+
+  return {
+    mode,
+    periods,
+    browserTimeZone,
+    fallbackTimeZone,
+    fixedTimeZone,
+    activeTimeZone,
+    resolveTimeZone,
+  };
+}

--- a/frontend/src/lib/timeZones.test.ts
+++ b/frontend/src/lib/timeZones.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  findTimeZonePeriod,
+  getTimelinePresetRange,
+  getZonedDateParts,
+  isValidTimeZone,
+  type TimelineTimeZonePeriod,
+  zonedDateTimeToUtc,
+} from "./timeZones";
+
+function period(
+  id: string,
+  start: string,
+  end: string,
+  timeZone: string,
+): TimelineTimeZonePeriod {
+  return {
+    _id: id,
+    start: new Date(start),
+    end: new Date(end),
+    timeZone,
+    source: "manual",
+  };
+}
+
+describe("timeline time zones", () => {
+  it("validates IANA time-zone identifiers", () => {
+    expect(isValidTimeZone("Europe/Paris")).toBe(true);
+    expect(isValidTimeZone("Asia/Tbilisi")).toBe(true);
+    expect(isValidTimeZone("Mars/Olympus_Mons")).toBe(false);
+  });
+
+  it("uses the newest overlapping period", () => {
+    const periods = [
+      period("old", "2026-07-01T00:00:00Z", "2026-08-01T00:00:00Z", "UTC"),
+      period(
+        "new",
+        "2026-07-20T00:00:00Z",
+        "2026-07-30T00:00:00Z",
+        "Europe/Paris",
+      ),
+    ];
+    expect(
+      findTimeZonePeriod(periods, new Date("2026-07-28T12:00:00Z"))?.timeZone,
+    )
+      .toBe("Europe/Paris");
+  });
+
+  it("converts a wall-clock midnight across daylight-saving time", () => {
+    expect(
+      zonedDateTimeToUtc(
+        { year: 2026, month: 7, day: 28 },
+        "Europe/Paris",
+      ).toISOString(),
+    ).toBe("2026-07-27T22:00:00.000Z");
+    expect(
+      zonedDateTimeToUtc(
+        { year: 2026, month: 1, day: 28 },
+        "Europe/Paris",
+      ).toISOString(),
+    ).toBe("2026-01-27T23:00:00.000Z");
+  });
+
+  it("builds Today from the selected time zone rather than the device zone", () => {
+    const range = getTimelinePresetRange(
+      "today",
+      new Date("2026-07-28T00:30:00.000Z"),
+      "Asia/Tokyo",
+    );
+    expect(range.start.toISOString()).toBe("2026-07-27T15:00:00.000Z");
+    expect(range.end.toISOString()).toBe("2026-07-28T00:30:00.000Z");
+  });
+
+  it("formats the same instant as different local calendar values", () => {
+    const instant = new Date("2026-07-28T22:30:00.000Z");
+    expect(getZonedDateParts(instant, "UTC")).toMatchObject({
+      year: 2026,
+      month: 7,
+      day: 28,
+      hour: 22,
+    });
+    expect(getZonedDateParts(instant, "Asia/Tbilisi")).toMatchObject({
+      year: 2026,
+      month: 7,
+      day: 29,
+      hour: 2,
+    });
+  });
+});

--- a/frontend/src/lib/timeZones.ts
+++ b/frontend/src/lib/timeZones.ts
@@ -1,0 +1,253 @@
+export const BROWSER_TIME_ZONE = "browser" as const;
+
+export type DefaultTimeZone = typeof BROWSER_TIME_ZONE | string;
+
+export interface TimelineTimeZonePeriod {
+  _id: { toString(): string } | string;
+  start: Date;
+  end: Date;
+  timeZone: string;
+  location?: {
+    name?: string;
+    latitude?: number;
+    longitude?: number;
+  };
+  source: "manual" | "import" | "metadata";
+  metadata?: Record<string, unknown>;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export function getBrowserTimeZone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+}
+
+export function resolveDefaultTimeZone(timeZone: DefaultTimeZone): string {
+  return timeZone === BROWSER_TIME_ZONE ? getBrowserTimeZone() : timeZone;
+}
+
+export function isValidTimeZone(timeZone: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone }).format();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const FALLBACK_TIME_ZONES = [
+  "UTC",
+  "America/Los_Angeles",
+  "America/New_York",
+  "America/Toronto",
+  "America/Mexico_City",
+  "America/Sao_Paulo",
+  "Europe/London",
+  "Europe/Paris",
+  "Europe/Berlin",
+  "Europe/Amsterdam",
+  "Europe/Moscow",
+  "Asia/Tbilisi",
+  "Asia/Dubai",
+  "Asia/Kolkata",
+  "Asia/Bangkok",
+  "Asia/Singapore",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+  "Pacific/Auckland",
+];
+
+export function getSupportedTimeZones(): string[] {
+  const intl = Intl as typeof Intl & {
+    supportedValuesOf?: (key: "timeZone") => string[];
+  };
+  const values = intl.supportedValuesOf?.("timeZone") ?? FALLBACK_TIME_ZONES;
+  return [...new Set(["UTC", ...values])].sort((a, b) => a.localeCompare(b));
+}
+
+export function getPeriodId(period: TimelineTimeZonePeriod): string {
+  return typeof period._id === "string" ? period._id : period._id.toString();
+}
+
+export function findTimeZonePeriod(
+  periods: TimelineTimeZonePeriod[],
+  instant: Date,
+): TimelineTimeZonePeriod | undefined {
+  const timestamp = instant.getTime();
+  return [...periods].reverse().find((period) =>
+    new Date(period.start).getTime() <= timestamp &&
+    timestamp < new Date(period.end).getTime()
+  );
+}
+
+export interface ZonedDateParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+}
+
+export function getZonedDateParts(
+  date: Date,
+  timeZone: string,
+): ZonedDateParts {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+  const values = Object.fromEntries(
+    parts.filter((part) => part.type !== "literal").map((part) => [
+      part.type,
+      Number(part.value),
+    ]),
+  );
+  return {
+    year: values.year,
+    month: values.month,
+    day: values.day,
+    hour: values.hour,
+    minute: values.minute,
+    second: values.second,
+  };
+}
+
+function getTimeZoneOffsetMs(date: Date, timeZone: string): number {
+  const parts = getZonedDateParts(date, timeZone);
+  const representedAsUtc = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second,
+  );
+  return representedAsUtc - Math.floor(date.getTime() / 1000) * 1000;
+}
+
+export function zonedDateTimeToUtc(
+  parts:
+    & Omit<ZonedDateParts, "hour" | "minute" | "second">
+    & Partial<Pick<ZonedDateParts, "hour" | "minute" | "second">>,
+  timeZone: string,
+): Date {
+  const wallClockUtc = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour ?? 0,
+    parts.minute ?? 0,
+    parts.second ?? 0,
+  );
+  let candidate = new Date(wallClockUtc);
+  for (let attempt = 0; attempt < 3; attempt++) {
+    candidate = new Date(
+      wallClockUtc - getTimeZoneOffsetMs(candidate, timeZone),
+    );
+  }
+  return candidate;
+}
+
+function shiftCalendarDate(
+  parts: Pick<ZonedDateParts, "year" | "month" | "day">,
+  days: number,
+) {
+  const shifted = new Date(
+    Date.UTC(parts.year, parts.month - 1, parts.day + days),
+  );
+  return {
+    year: shifted.getUTCFullYear(),
+    month: shifted.getUTCMonth() + 1,
+    day: shifted.getUTCDate(),
+  };
+}
+
+export type TimelinePreset =
+  | "last5min"
+  | "lastHour"
+  | "today"
+  | "yesterday"
+  | "thisWeek"
+  | "currentMonth"
+  | "yearToDate"
+  | "pastYear";
+
+export function getTimelinePresetRange(
+  preset: TimelinePreset,
+  now: Date,
+  timeZone: string,
+): { start: Date; end: Date } {
+  if (preset === "last5min") {
+    return { start: new Date(now.getTime() - 5 * 60_000), end: now };
+  }
+  if (preset === "lastHour") {
+    return { start: new Date(now.getTime() - 60 * 60_000), end: now };
+  }
+  if (preset === "pastYear") {
+    return {
+      start: new Date(now.getTime() - 365 * 24 * 60 * 60_000),
+      end: now,
+    };
+  }
+
+  const today = getZonedDateParts(now, timeZone);
+  const todayDate = { year: today.year, month: today.month, day: today.day };
+  const todayStart = zonedDateTimeToUtc(todayDate, timeZone);
+
+  if (preset === "today") return { start: todayStart, end: now };
+  if (preset === "yesterday") {
+    return {
+      start: zonedDateTimeToUtc(shiftCalendarDate(todayDate, -1), timeZone),
+      end: todayStart,
+    };
+  }
+  if (preset === "currentMonth") {
+    return {
+      start: zonedDateTimeToUtc({ ...todayDate, day: 1 }, timeZone),
+      end: now,
+    };
+  }
+  if (preset === "yearToDate") {
+    return {
+      start: zonedDateTimeToUtc(
+        { year: today.year, month: 1, day: 1 },
+        timeZone,
+      ),
+      end: now,
+    };
+  }
+
+  const dayOfWeek = new Date(
+    Date.UTC(today.year, today.month - 1, today.day),
+  ).getUTCDay();
+  const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+  return {
+    start: zonedDateTimeToUtc(
+      shiftCalendarDate(todayDate, mondayOffset),
+      timeZone,
+    ),
+    end: now,
+  };
+}
+
+export function getShortTimeZoneName(date: Date, timeZone: string): string {
+  const part = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    timeZoneName: "short",
+  }).formatToParts(date).find((item) => item.type === "timeZoneName");
+  return part?.value ?? timeZone;
+}
+
+export function isSameZonedDay(a: Date, b: Date, timeZone: string): boolean {
+  const first = getZonedDateParts(a, timeZone);
+  const second = getZonedDateParts(b, timeZone);
+  return first.year === second.year && first.month === second.month &&
+    first.day === second.day;
+}

--- a/frontend/src/modules/time/formatters/gregorian.test.ts
+++ b/frontend/src/modules/time/formatters/gregorian.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { formatLabel } from "./gregorian";
+
+describe("Gregorian timeline labels", () => {
+  it("formats a tick in the requested IANA time zone", () => {
+    const labels = formatLabel(
+      new Date("2026-07-28T12:00:00.000Z"),
+      { hasSeconds: false },
+      "Asia/Tbilisi",
+    ).map(String);
+
+    expect(labels[0]).toMatch(/16:00/);
+    expect(labels).toContain("GMT+4");
+    expect(labels).toContain("Jul 28");
+  });
+});

--- a/frontend/src/modules/time/formatters/gregorian.ts
+++ b/frontend/src/modules/time/formatters/gregorian.ts
@@ -1,20 +1,29 @@
 import * as d3 from "d3";
 import React from "react";
 import { Label, Tick } from "./types.ts";
+import { getShortTimeZoneName, getZonedDateParts } from "@/lib/timeZones";
 
 const day = 1000 * 60 * 60 * 24;
 
-const checkAllJanFirst = (ticks: Tick[]): boolean => {
+const checkAllJanFirst = (
+  ticks: Tick[],
+  resolveTimeZone: (date: Date) => string,
+): boolean => {
   return ticks.length > 0 &&
-    ticks.every(({ value }) => value.getMonth() === 0 && value.getDate() === 1);
+    ticks.every(({ value }) => {
+      const parts = getZonedDateParts(value, resolveTimeZone(value));
+      return parts.month === 1 && parts.day === 1;
+    });
 };
 
-const checkHasTime = (ticks: Tick[]): boolean => {
-  return ticks.some(({ value }) => (
-    value.getHours() !== 0 ||
-    value.getMinutes() !== 0 ||
-    value.getSeconds() !== 0
-  ));
+const checkHasTime = (
+  ticks: Tick[],
+  resolveTimeZone: (date: Date) => string,
+): boolean => {
+  return ticks.some(({ value }) => {
+    const parts = getZonedDateParts(value, resolveTimeZone(value));
+    return parts.hour !== 0 || parts.minute !== 0 || parts.second !== 0;
+  });
 };
 
 const checkHasWeekdays = (ticks: Tick[]): boolean => {
@@ -23,8 +32,13 @@ const checkHasWeekdays = (ticks: Tick[]): boolean => {
   return last.getTime() - first.getTime() < 30 * day;
 };
 
-const checkHasSeconds = (ticks: Tick[]): boolean => {
-  return ticks.some(({ value }) => value.getSeconds() !== 0);
+const checkHasSeconds = (
+  ticks: Tick[],
+  resolveTimeZone: (date: Date) => string,
+): boolean => {
+  return ticks.some(({ value }) =>
+    getZonedDateParts(value, resolveTimeZone(value)).second !== 0
+  );
 };
 
 const checkHasMilliseconds = (ticks: Tick[]): boolean => {
@@ -35,9 +49,11 @@ const formatTime = (
   date: Date,
   hasSeconds: boolean,
   hasMilliseconds: boolean,
+  timeZone: string,
 ): string => {
   if (hasMilliseconds) {
     return date.toLocaleTimeString([], {
+      timeZone,
       hour: "2-digit",
       minute: "2-digit",
       second: "2-digit",
@@ -47,12 +63,14 @@ const formatTime = (
 
   return hasSeconds
     ? date.toLocaleTimeString([], {
+      timeZone,
       hour: "2-digit",
       minute: "2-digit",
       second: "2-digit",
       hour12: false,
     })
     : date.toLocaleTimeString([], {
+      timeZone,
       hour: "2-digit",
       minute: "2-digit",
       hour12: false,
@@ -68,8 +86,10 @@ export const formatLabel = (
     hasSeconds?: boolean;
     hasMilliseconds?: boolean;
   },
+  timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
 ): React.ReactNode[] => {
-  const year = date.getFullYear().toString();
+  const parts = getZonedDateParts(date, timeZone);
+  const year = parts.year.toString();
   const defaults = {
     allJanFirst: false,
     hasTime: true,
@@ -87,12 +107,13 @@ export const formatLabel = (
     return [year];
   }
 
-  const month = date.toLocaleDateString([], { month: "short" });
-  const day = date.getDate();
-  const weekday = date.toLocaleDateString([], { weekday: "short" });
+  const month = date.toLocaleDateString([], { month: "short", timeZone });
+  const day = parts.day;
+  const weekday = date.toLocaleDateString([], { weekday: "short", timeZone });
 
   return [
-    hasTime ? formatTime(date, hasSeconds, hasMilliseconds) : null,
+    hasTime ? formatTime(date, hasSeconds, hasMilliseconds, timeZone) : null,
+    hasTime ? getShortTimeZoneName(date, timeZone) : null,
     hasWeekdays ? weekday : null,
     `${month} ${day}`,
     year,
@@ -103,7 +124,11 @@ const generateGregorianLabels = (
   scale: d3.ScaleTime<number, number>,
   transform: d3.ZoomTransform,
   width: number,
+  context?: { resolveTimeZone?: (date: Date) => string },
 ): Label[] => {
+  const browserTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone ||
+    "UTC";
+  const resolveTimeZone = context?.resolveTimeZone ?? (() => browserTimeZone);
   const newScale = transform.rescaleX(scale);
   const tickValues = newScale.ticks(Math.ceil(width / 227));
   const ticks = tickValues.map((tick) => ({
@@ -111,17 +136,19 @@ const generateGregorianLabels = (
     xOffset: newScale(tick),
   }));
 
-  const allJanFirst = checkAllJanFirst(ticks);
-  const hasTime = checkHasTime(ticks);
+  const allJanFirst = checkAllJanFirst(ticks, resolveTimeZone);
+  const hasTime = checkHasTime(ticks, resolveTimeZone);
   const hasWeekdays = checkHasWeekdays(ticks);
-  const hasSeconds = checkHasSeconds(ticks);
+  const hasSeconds = checkHasSeconds(ticks, resolveTimeZone);
   const hasMilliseconds = checkHasMilliseconds(ticks);
 
   let prev: React.ReactNode[] | null = null;
   return ticks.map(({ value, xOffset }) => {
+    const timeZone = resolveTimeZone(value);
     const fullSegments = formatLabel(
       value,
       { allJanFirst, hasTime, hasWeekdays, hasSeconds, hasMilliseconds },
+      timeZone,
     );
     const result = {
       value,

--- a/frontend/src/modules/time/formatters/types.ts
+++ b/frontend/src/modules/time/formatters/types.ts
@@ -15,4 +15,7 @@ export type Formatter = (
   scale: d3.ScaleTime<number, number>,
   transform: d3.ZoomTransform,
   width: number,
+  context?: {
+    resolveTimeZone?: (date: Date) => string;
+  },
 ) => Label[];

--- a/frontend/src/modules/time/index.tsx
+++ b/frontend/src/modules/time/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useEffect } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { Layer, LayerComponentProps } from "@/core/core.ts";
 import { useTimelineSelectionStore } from "@/stores/timelineSelectionStore.ts";
 
@@ -6,6 +6,7 @@ import { Formatter, Label } from "./formatters/types.ts";
 
 import gregorianFormatter from "./formatters/gregorian.ts";
 import siFormatter from "./formatters/si.ts";
+import { useTimelineTimeZone } from "@/hooks/useTimelineTimeZone";
 
 export const GregorianFormatter: Formatter = gregorianFormatter;
 export const SiFormatter: Formatter = siFormatter;
@@ -21,6 +22,7 @@ export const TimeLayer: (options?: TimeLayerOptions) => Layer = (
 ) => {
   return {
     component: ({ scale, transform, width }: LayerComponentProps) => {
+      const { resolveTimeZone } = useTimelineTimeZone();
       const { selection, setSelection } = useTimelineSelectionStore();
       const svgRef = useRef<SVGSVGElement>(null);
       const isSelectingRef = useRef(false);
@@ -32,7 +34,7 @@ export const TimeLayer: (options?: TimeLayerOptions) => Layer = (
       const selectionRef = useRef(selection);
       const scaleRef = useRef(scale);
       const transformRef = useRef(transform);
-      
+
       useEffect(() => {
         selectionRef.current = selection;
       }, [selection]);
@@ -73,17 +75,20 @@ export const TimeLayer: (options?: TimeLayerOptions) => Layer = (
             } else {
               setSelection({ start: newTime, end: start });
             }
-          } else if (isSelectingRef.current && selectionStartXRef.current !== null && selectionStartTimeRef.current !== null) {
+          } else if (
+            isSelectingRef.current && selectionStartXRef.current !== null &&
+            selectionStartTimeRef.current !== null
+          ) {
             const deltaX = Math.abs(x - selectionStartXRef.current);
-            
+
             if (deltaX > 3) {
               hasMovedRef.current = true;
             }
-            
+
             if (hasMovedRef.current) {
               const endTime = rescaledScale.invert(clampedX);
               const startTime = selectionStartTimeRef.current;
-              
+
               if (startTime <= endTime) {
                 setSelection({ start: startTime, end: endTime });
               } else {
@@ -93,47 +98,63 @@ export const TimeLayer: (options?: TimeLayerOptions) => Layer = (
           } else {
             return;
           }
-          
+
           e.preventDefault();
           e.stopPropagation();
         };
 
         const handleDocumentMouseUp = (e: MouseEvent) => {
           if (!isSelectingRef.current && !draggingHandleRef.current) return;
-          
+
           if (draggingHandleRef.current) {
             draggingHandleRef.current = null;
             handleStartTimeRef.current = null;
           } else if (isSelectingRef.current) {
-            if (!hasMovedRef.current && setSelection && selectionStartTimeRef.current) {
+            if (
+              !hasMovedRef.current && setSelection &&
+              selectionStartTimeRef.current
+            ) {
               setSelection({ start: null, end: null });
             }
-            
+
             isSelectingRef.current = false;
             selectionStartXRef.current = null;
             selectionStartTimeRef.current = null;
             hasMovedRef.current = false;
           }
-          
-          document.removeEventListener("mousemove", handleDocumentMouseMove, { capture: true });
-          document.removeEventListener("mouseup", handleDocumentMouseUp, { capture: true });
-          
+
+          document.removeEventListener("mousemove", handleDocumentMouseMove, {
+            capture: true,
+          });
+          document.removeEventListener("mouseup", handleDocumentMouseUp, {
+            capture: true,
+          });
+
           e.preventDefault();
           e.stopPropagation();
         };
 
-        const handleHandleMouseDown = (e: MouseEvent, handle: "left" | "right") => {
+        const handleHandleMouseDown = (
+          e: MouseEvent,
+          handle: "left" | "right",
+        ) => {
           if (e.button !== 0) return;
           if (!setSelection) return;
           const currentSelection = selectionRef.current;
           if (!currentSelection?.start || !currentSelection?.end) return;
 
           draggingHandleRef.current = handle;
-          handleStartTimeRef.current = handle === "left" ? currentSelection.start : currentSelection.end;
-          
-          document.addEventListener("mousemove", handleDocumentMouseMove, { capture: true });
-          document.addEventListener("mouseup", handleDocumentMouseUp, { capture: true });
-          
+          handleStartTimeRef.current = handle === "left"
+            ? currentSelection.start
+            : currentSelection.end;
+
+          document.addEventListener("mousemove", handleDocumentMouseMove, {
+            capture: true,
+          });
+          document.addEventListener("mouseup", handleDocumentMouseUp, {
+            capture: true,
+          });
+
           e.preventDefault();
           e.stopPropagation();
         };
@@ -144,35 +165,49 @@ export const TimeLayer: (options?: TimeLayerOptions) => Layer = (
 
           const target = e.target as Element;
           if (target.classList.contains("selection-handle")) {
-            const handle = target.classList.contains("selection-handle-left") ? "left" : "right";
+            const handle = target.classList.contains("selection-handle-left")
+              ? "left"
+              : "right";
             handleHandleMouseDown(e, handle);
             return;
           }
 
           const rect = svg.getBoundingClientRect();
           const x = e.clientX - rect.left;
-          
+
           isSelectingRef.current = true;
           selectionStartXRef.current = x;
           hasMovedRef.current = false;
-          
+
           const rescaledScale = transformRef.current.rescaleX(scaleRef.current);
           const startTime = rescaledScale.invert(x);
           selectionStartTimeRef.current = startTime;
-          
-          document.addEventListener("mousemove", handleDocumentMouseMove, { capture: true });
-          document.addEventListener("mouseup", handleDocumentMouseUp, { capture: true });
-          
+
+          document.addEventListener("mousemove", handleDocumentMouseMove, {
+            capture: true,
+          });
+          document.addEventListener("mouseup", handleDocumentMouseUp, {
+            capture: true,
+          });
+
           e.preventDefault();
           e.stopPropagation();
         };
 
-        svg.addEventListener("mousedown", handleNativeMouseDown, { capture: true });
+        svg.addEventListener("mousedown", handleNativeMouseDown, {
+          capture: true,
+        });
 
         return () => {
-          svg.removeEventListener("mousedown", handleNativeMouseDown, { capture: true });
-          document.removeEventListener("mousemove", handleDocumentMouseMove, { capture: true });
-          document.removeEventListener("mouseup", handleDocumentMouseUp, { capture: true });
+          svg.removeEventListener("mousedown", handleNativeMouseDown, {
+            capture: true,
+          });
+          document.removeEventListener("mousemove", handleDocumentMouseMove, {
+            capture: true,
+          });
+          document.removeEventListener("mouseup", handleDocumentMouseUp, {
+            capture: true,
+          });
         };
       }, [width, setSelection]);
 
@@ -182,32 +217,31 @@ export const TimeLayer: (options?: TimeLayerOptions) => Layer = (
         const rescaledScale = transform.rescaleX(scale);
         const x1 = rescaledScale(selection.start);
         const x2 = rescaledScale(selection.end);
-        
+
         const left = Math.min(x1, x2);
         const rectWidth = Math.abs(x2 - x1);
 
         if (Number.isNaN(rectWidth)) return null;
 
-        return { left, width: rectWidth, start: selection.start, end: selection.end };
+        return {
+          left,
+          width: rectWidth,
+          start: selection.start,
+          end: selection.end,
+        };
       }, [selection, scale, transform]);
 
       const formatSelectionDate = (date: Date) => {
-        const now = new Date();
-        const isToday = date.toDateString() === now.toDateString();
-        const yesterday = new Date(now);
-        yesterday.setDate(yesterday.getDate() - 1);
-        const isYesterday = date.toDateString() === yesterday.toDateString();
-        
-        const timeStr = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-        
-        if (isToday) {
-          return timeStr;
-        } else if (isYesterday) {
-          return `Yesterday ${timeStr}`;
-        } else {
-          const dateStr = date.toLocaleDateString([], { month: 'short', day: 'numeric' });
-          return `${dateStr} ${timeStr}`;
-        }
+        const timeZone = resolveTimeZone(date);
+        return new Intl.DateTimeFormat(undefined, {
+          timeZone,
+          month: "short",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+          timeZoneName: "short",
+        }).format(date);
       };
 
       const formatDuration = (start: Date, end: Date) => {
@@ -216,23 +250,23 @@ export const TimeLayer: (options?: TimeLayerOptions) => Layer = (
         const diffMinutes = Math.floor(diffSeconds / 60);
         const diffHours = Math.floor(diffMinutes / 60);
         const diffDays = Math.floor(diffHours / 24);
-        
+
         if (diffDays > 0) {
           const remainingHours = diffHours % 24;
           if (remainingHours > 0) {
             return `${diffDays}d ${remainingHours}h`;
           }
-          return `${diffDays} day${diffDays !== 1 ? 's' : ''}`;
+          return `${diffDays} day${diffDays !== 1 ? "s" : ""}`;
         } else if (diffHours > 0) {
           const remainingMinutes = diffMinutes % 60;
           if (remainingMinutes > 0) {
             return `${diffHours}h ${remainingMinutes}m`;
           }
-          return `${diffHours} hour${diffHours !== 1 ? 's' : ''}`;
+          return `${diffHours} hour${diffHours !== 1 ? "s" : ""}`;
         } else if (diffMinutes > 0) {
-          return `${diffMinutes} min${diffMinutes !== 1 ? 's' : ''}`;
+          return `${diffMinutes} min${diffMinutes !== 1 ? "s" : ""}`;
         } else {
-          return `${diffSeconds} sec${diffSeconds !== 1 ? 's' : ''}`;
+          return `${diffSeconds} sec${diffSeconds !== 1 ? "s" : ""}`;
         }
       };
 
@@ -287,7 +321,7 @@ export const TimeLayer: (options?: TimeLayerOptions) => Layer = (
                 strokeWidth={1}
                 pointerEvents="none"
               />
-              
+
               {/* Visual Handles */}
               <rect
                 x={selectionRect.left - 2}
@@ -309,7 +343,7 @@ export const TimeLayer: (options?: TimeLayerOptions) => Layer = (
                 strokeWidth={1}
                 pointerEvents="none"
               />
-              
+
               {/* Start date/time label */}
               <foreignObject
                 x={selectionRect.left - 60}
@@ -324,7 +358,7 @@ export const TimeLayer: (options?: TimeLayerOptions) => Layer = (
                   </span>
                 </div>
               </foreignObject>
-              
+
               {/* End date/time label */}
               <foreignObject
                 x={selectionRect.left + selectionRect.width - 60}
@@ -339,7 +373,7 @@ export const TimeLayer: (options?: TimeLayerOptions) => Layer = (
                   </span>
                 </div>
               </foreignObject>
-              
+
               {/* Duration label in center */}
               {selectionRect.width > 60 && (
                 <foreignObject
@@ -358,38 +392,39 @@ export const TimeLayer: (options?: TimeLayerOptions) => Layer = (
               )}
             </>
           )}
-        <TimelineAxis
-          scale={scale}
-          transform={transform}
-          width={width}
-          formatter={options.formatter}
-        />
-        {selectionRect && (
-          <>
-            {/* Interactive Hit Areas */}
-            <rect
-              className="selection-handle selection-handle-left"
-              x={selectionRect.left - 5}
-              y={0}
-              width={10}
-              height={40}
-              fill="transparent"
-              style={{ cursor: "ew-resize" }}
-              pointerEvents="all"
-            />
-            <rect
-              className="selection-handle selection-handle-right"
-              x={selectionRect.left + selectionRect.width - 5}
-              y={0}
-              width={10}
-              height={40}
-              fill="transparent"
-              style={{ cursor: "ew-resize" }}
-              pointerEvents="all"
-            />
-          </>
-        )}
-      </svg>
+          <TimelineAxis
+            scale={scale}
+            transform={transform}
+            width={width}
+            formatter={options.formatter}
+            resolveTimeZone={resolveTimeZone}
+          />
+          {selectionRect && (
+            <>
+              {/* Interactive Hit Areas */}
+              <rect
+                className="selection-handle selection-handle-left"
+                x={selectionRect.left - 5}
+                y={0}
+                width={10}
+                height={40}
+                fill="transparent"
+                style={{ cursor: "ew-resize" }}
+                pointerEvents="all"
+              />
+              <rect
+                className="selection-handle selection-handle-right"
+                x={selectionRect.left + selectionRect.width - 5}
+                y={0}
+                width={10}
+                height={40}
+                fill="transparent"
+                style={{ cursor: "ew-resize" }}
+                pointerEvents="all"
+              />
+            </>
+          )}
+        </svg>
       );
     },
   } as Layer;
@@ -397,6 +432,7 @@ export const TimeLayer: (options?: TimeLayerOptions) => Layer = (
 
 interface TimelineAxisProps extends LayerComponentProps {
   formatter: Formatter;
+  resolveTimeZone: (date: Date) => string;
 }
 
 const TimelineAxis = ({
@@ -404,12 +440,17 @@ const TimelineAxis = ({
   transform,
   width,
   formatter = gregorianFormatter,
+  resolveTimeZone,
 }: TimelineAxisProps) => {
-  const labels = useMemo(() => formatter(scale, transform, width), [
-    scale,
-    transform,
-    formatter,
-  ]);
+  const labels = useMemo(
+    () => formatter(scale, transform, width, { resolveTimeZone }),
+    [
+      scale,
+      transform,
+      formatter,
+      resolveTimeZone,
+    ],
+  );
 
   // TODO: Be able Big Bang to the timeline 3.787 ± 0.020 billion years ago. (Doesn't fit in JS number precision rn)
 

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { MultiTrackTimeline } from "@/components/timeline/MultiTrackTimeline";
 import { TimelineHeader } from "@/components/timeline/TimelineHeader";
@@ -12,6 +12,9 @@ import { useSpanningObjectsStore } from "@/stores/spanningObjectsStore";
 import { useTimeline } from "@/hooks/useTimeline";
 import { useTimelineRange } from "@/stores/timelineRange";
 import { api } from "@/lib/api";
+import { useTimelineTimeZoneStore } from "@/stores/timelineTimeZoneStore";
+import { useTimelineTimeZone } from "@/hooks/useTimelineTimeZone";
+import { getTimelinePresetRange, type TimelinePreset } from "@/lib/timeZones";
 
 const TimelinePage = () => {
   const location = useLocation();
@@ -30,8 +33,20 @@ const TimelinePage = () => {
 
   const timeline = useTimeline();
   const { zoomTo } = timeline;
-  const setRange = useTimelineRange((s) => s.setRange);
+  const { start: timelineStart, end: timelineEnd, setRange } =
+    useTimelineRange();
+  const fetchTimeZones = useTimelineTimeZoneStore((state) =>
+    state.fetchForRange
+  );
+  const { resolveTimeZone } = useTimelineTimeZone();
   const hasTimeSelection = !!(timeSelection.start && timeSelection.end);
+
+  useEffect(() => {
+    const timeout = globalThis.setTimeout(() => {
+      fetchTimeZones(timelineStart, timelineEnd);
+    }, 150);
+    return () => globalThis.clearTimeout(timeout);
+  }, [fetchTimeZones, timelineEnd, timelineStart]);
 
   // Apply start/end from URL when navigating to timeline with ?start=&end= (e.g. "View on timeline" from object)
   useEffect(() => {
@@ -47,11 +62,12 @@ const TimelinePage = () => {
     setRange(start, end);
   }, [location.search, setRange]);
 
-  const isShortRange =
+  const isShortRange = Boolean(
     timeSelection.start &&
-    timeSelection.end &&
-    timeSelection.end.getTime() - timeSelection.start.getTime() <
-      24 * 60 * 60 * 1000;
+      timeSelection.end &&
+      timeSelection.end.getTime() - timeSelection.start.getTime() <
+        24 * 60 * 60 * 1000,
+  );
 
   // Clear selection when navigating away
   useEffect(() => {
@@ -101,8 +117,12 @@ const TimelinePage = () => {
       });
 
       if (result.start && result.end) {
-        const earliest = result.start instanceof Date ? result.start : new Date(result.start);
-        const latest = result.end instanceof Date ? result.end : new Date(result.end);
+        const earliest = result.start instanceof Date
+          ? result.start
+          : new Date(result.start);
+        const latest = result.end instanceof Date
+          ? result.end
+          : new Date(result.end);
 
         const duration = latest.getTime() - earliest.getTime();
         const padding = duration * 0.05;
@@ -117,46 +137,23 @@ const TimelinePage = () => {
 
   const handleTimeRangeSelect = (range: string) => {
     const now = new Date();
-    let start: Date;
-    let end: Date = now;
-
-    switch (range) {
-      case "last5min":
-        start = new Date(now.getTime() - 5 * 60 * 1000);
-        break;
-      case "lastHour":
-        start = new Date(now.getTime() - 60 * 60 * 1000);
-        break;
-      case "today":
-        start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-        break;
-      case "yesterday":
-        start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1);
-        end = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-        break;
-      case "thisWeek": {
-        const dayOfWeek = now.getDay();
-        const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
-        start = new Date(
-          now.getFullYear(),
-          now.getMonth(),
-          now.getDate() + mondayOffset,
-        );
-        break;
-      }
-      case "currentMonth":
-        start = new Date(now.getFullYear(), now.getMonth(), 1);
-        break;
-      case "yearToDate":
-        start = new Date(now.getFullYear(), 0, 1);
-        break;
-      case "pastYear":
-        start = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000);
-        break;
-      default:
-        return;
-    }
-
+    const supported = [
+      "last5min",
+      "lastHour",
+      "today",
+      "yesterday",
+      "thisWeek",
+      "currentMonth",
+      "yearToDate",
+      "pastYear",
+    ] as const;
+    if (!supported.includes(range as TimelinePreset)) return;
+    const timeZone = resolveTimeZone(now);
+    const { start, end } = getTimelinePresetRange(
+      range as TimelinePreset,
+      now,
+      timeZone,
+    );
     zoomTo(start, end);
   };
 
@@ -180,8 +177,8 @@ const TimelinePage = () => {
         <div className="flex-1 space-y-6 min-w-0">
           <TimelineHeader
             hasTimeSelection={hasTimeSelection}
-            timeSelectionStart={timeSelection.start}
-            timeSelectionEnd={timeSelection.end}
+            timeSelectionStart={timeSelection.start ?? undefined}
+            timeSelectionEnd={timeSelection.end ?? undefined}
             isShortRange={isShortRange}
             onZoomToFit={handleZoomToFit}
             onTimeRangeSelect={handleTimeRangeSelect}

--- a/frontend/src/pages/settings/GeneralSettingsPage.tsx
+++ b/frontend/src/pages/settings/GeneralSettingsPage.tsx
@@ -5,14 +5,18 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Monitor, Moon, Sun } from "lucide-react";
 import { formatTime } from "@/lib/formatTime";
+import { TimeZoneSelect } from "@/components/TimeZoneSelect";
+import { getBrowserTimeZone, resolveDefaultTimeZone } from "@/lib/timeZones";
 
 const GeneralSettingsPage = () => {
   const {
     theme,
     timeFormat,
+    defaultTimeZone,
     transcriptThresholdHours,
     setTheme,
     setTimeFormat,
+    setDefaultTimeZone,
     setTranscriptThresholdHours,
   } = useSettingsStore();
   const now = useMemo(() => new Date(), []);
@@ -111,6 +115,22 @@ const GeneralSettingsPage = () => {
             </select>
             <p className="text-xs text-muted-foreground">
               Choose how dates and times are displayed across the application
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="defaultTimeZone">Default Time Zone</Label>
+            <TimeZoneSelect
+              id="defaultTimeZone"
+              value={defaultTimeZone}
+              onChange={setDefaultTimeZone}
+              includeBrowser
+            />
+            <p className="text-xs text-muted-foreground">
+              Used when a timeline instant has no saved time-zone period.
+              Current resolved zone:{" "}
+              {resolveDefaultTimeZone(defaultTimeZone)}. Device zone:{" "}
+              {getBrowserTimeZone()}.
             </p>
           </div>
 

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -1,7 +1,9 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { BROWSER_TIME_ZONE, type DefaultTimeZone } from "@/lib/timeZones";
 
 type Theme = "light" | "dark" | "system";
+export type TimelineTimeZoneMode = "contextual" | "browser" | "fixed";
 
 type TimeFormat =
   | "gregorian-local-natural"
@@ -22,6 +24,9 @@ interface SettingsState {
   clientSecret: string;
   theme: Theme;
   timeFormat: TimeFormat;
+  defaultTimeZone: DefaultTimeZone;
+  timelineTimeZoneMode: TimelineTimeZoneMode;
+  timelineTimeZoneOverride: string;
   transcriptThresholdHours: number;
   preferredAudioDeviceId: string | null;
   echoCancellation: boolean;
@@ -35,6 +40,9 @@ interface SettingsState {
   setClientSecret: (secret: string) => void;
   setTheme: (theme: Theme) => void;
   setTimeFormat: (format: TimeFormat) => void;
+  setDefaultTimeZone: (timeZone: DefaultTimeZone) => void;
+  setTimelineTimeZoneMode: (mode: TimelineTimeZoneMode) => void;
+  setTimelineTimeZoneOverride: (timeZone: string) => void;
   setTranscriptThresholdHours: (hours: number) => void;
   setPreferredAudioDeviceId: (deviceId: string | null) => void;
   setEchoCancellation: (enabled: boolean) => void;
@@ -64,6 +72,9 @@ export const useSettingsStore = create<SettingsState>()(
       clientSecret: "",
       theme: "system",
       timeFormat: DEFAULT_TIME_FORMAT,
+      defaultTimeZone: BROWSER_TIME_ZONE,
+      timelineTimeZoneMode: "contextual",
+      timelineTimeZoneOverride: "UTC",
       transcriptThresholdHours: DEFAULT_TRANSCRIPT_THRESHOLD_HOURS,
       preferredAudioDeviceId: null,
       echoCancellation: true,
@@ -77,6 +88,10 @@ export const useSettingsStore = create<SettingsState>()(
       setClientSecret: (secret) => set({ clientSecret: secret }),
       setTheme: (theme) => set({ theme }),
       setTimeFormat: (format) => set({ timeFormat: format }),
+      setDefaultTimeZone: (timeZone) => set({ defaultTimeZone: timeZone }),
+      setTimelineTimeZoneMode: (mode) => set({ timelineTimeZoneMode: mode }),
+      setTimelineTimeZoneOverride: (timeZone) =>
+        set({ timelineTimeZoneOverride: timeZone }),
       setTranscriptThresholdHours: (hours) =>
         set({ transcriptThresholdHours: hours }),
       setPreferredAudioDeviceId: (deviceId) =>
@@ -94,6 +109,9 @@ export const useSettingsStore = create<SettingsState>()(
           clientSecret: "",
           theme: "system",
           timeFormat: DEFAULT_TIME_FORMAT,
+          defaultTimeZone: BROWSER_TIME_ZONE,
+          timelineTimeZoneMode: "contextual",
+          timelineTimeZoneOverride: "UTC",
           transcriptThresholdHours: DEFAULT_TRANSCRIPT_THRESHOLD_HOURS,
           preferredAudioDeviceId: null,
           echoCancellation: true,

--- a/frontend/src/stores/timelineTimeZoneStore.ts
+++ b/frontend/src/stores/timelineTimeZoneStore.ts
@@ -1,0 +1,100 @@
+import { create } from "zustand";
+import { callResource } from "@/lib/api";
+import { getPeriodId, type TimelineTimeZonePeriod } from "@/lib/timeZones";
+
+interface CreateTimelineTimeZonePeriod {
+  start: Date;
+  end: Date;
+  timeZone: string;
+  location?: { name?: string; latitude?: number; longitude?: number };
+  source?: "manual" | "import" | "metadata";
+  metadata?: Record<string, unknown>;
+}
+
+interface TimelineTimeZoneState {
+  periods: TimelineTimeZonePeriod[];
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+  requestedRange: { start: number; end: number } | null;
+  fetchForRange: (start: Date, end: Date) => Promise<void>;
+  createPeriod: (
+    period: CreateTimelineTimeZonePeriod,
+  ) => Promise<TimelineTimeZonePeriod>;
+  deletePeriod: (id: string) => Promise<void>;
+}
+
+export const useTimelineTimeZoneStore = create<TimelineTimeZoneState>(
+  (set, get) => ({
+    periods: [],
+    loading: false,
+    saving: false,
+    error: null,
+    requestedRange: null,
+
+    fetchForRange: async (start, end) => {
+      const request = { start: start.getTime(), end: end.getTime() };
+      const current = get().requestedRange;
+      if (current?.start === request.start && current.end === request.end) {
+        return;
+      }
+
+      set({ loading: true, error: null, requestedRange: request });
+      try {
+        const periods = await callResource("timeline-timezones", {
+          action: "list",
+          start,
+          end,
+        });
+        set({ periods, loading: false });
+      } catch (error) {
+        set({
+          error: error instanceof Error
+            ? error.message
+            : "Failed to load time zones",
+          loading: false,
+        });
+      }
+    },
+
+    createPeriod: async (period) => {
+      set({ saving: true, error: null });
+      try {
+        const created = await callResource("timeline-timezones", {
+          action: "create",
+          period: { ...period, source: period.source ?? "manual" },
+        }) as TimelineTimeZonePeriod;
+        set((state) => ({
+          periods: [...state.periods, created].sort(
+            (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+          ),
+          saving: false,
+        }));
+        return created;
+      } catch (error) {
+        const message = error instanceof Error
+          ? error.message
+          : "Failed to save time zone";
+        set({ error: message, saving: false });
+        throw error;
+      }
+    },
+
+    deletePeriod: async (id) => {
+      set({ saving: true, error: null });
+      try {
+        await callResource("timeline-timezones", { action: "delete", id });
+        set((state) => ({
+          periods: state.periods.filter((period) => getPeriodId(period) !== id),
+          saving: false,
+        }));
+      } catch (error) {
+        const message = error instanceof Error
+          ? error.message
+          : "Failed to delete time zone";
+        set({ error: message, saving: false });
+        throw error;
+      }
+    },
+  }),
+);


### PR DESCRIPTION
## What changed

- add contextual, device, and fixed time-zone display modes to the timeline
- format timeline ticks, selections, and date presets in the effective IANA time zone
- persist manual historical time-zone periods with optional place, source, and metadata in MongoDB
- show saved time-zone periods as a timeline context band
- add a default time-zone preference in General Settings
- add migration indexes and DST/IANA validation tests

## Why

Timeline data was recorded across multiple locations, while the UI formatted all timestamps in the browser's local zone. This makes historical days and times misleading after travel.

## Validation

- `deno task build`
- `deno test -A app/lib/timezones/resource.server.test.ts` (3 passed)
- targeted Vitest time-zone tests (6 passed)
- targeted frontend/backend `deno lint` and backend `deno check`
- live browser verification of the timeline selector and General Settings default

## Known baseline

`TimelinePage.test.tsx` still fails before exercising assertions because its existing harness does not install a React Query `QueryClientProvider`; this is unrelated to the change.