### PR TITLE
Timeline: searchable time zones, favorites, and period save fix

### DIFF
--- a/backend/app/lib/timezones/resource.server.test.ts
+++ b/backend/app/lib/timezones/resource.server.test.ts
@@ -40,3 +40,18 @@ Deno.test("timeline time zone periods preserve import provenance", () => {
   expect(result.period.source).toBe("metadata");
   expect(result.period.location?.name).toBe("Metz");
 });
+
+Deno.test("timeline time zone periods accept null location from EJSON clients", () => {
+  const result = timelineTimeZonesRequestSchema.parse({
+    action: "create",
+    period: {
+      start: "2026-07-28T10:00:00.000Z",
+      end: "2026-07-28T11:00:00.000Z",
+      timeZone: "Asia/Bangkok",
+      location: null,
+    },
+  });
+
+  if (result.action !== "create") throw new Error("Expected create action");
+  expect(result.period.location).toBe(undefined);
+});

--- a/backend/app/lib/timezones/resource.server.ts
+++ b/backend/app/lib/timezones/resource.server.ts
@@ -27,11 +27,15 @@ const locationSchema = z.object({
   { message: "Latitude and longitude must be provided together" },
 );
 
+const optionalLocationSchema = locationSchema.nullish().transform((value) =>
+  value ?? undefined
+);
+
 const periodInputSchema = z.object({
   start: zDateOrString(),
   end: zDateOrString(),
   timeZone: timeZoneSchema,
-  location: locationSchema.optional(),
+  location: optionalLocationSchema,
   source: z.enum(["manual", "import", "metadata"]).default("manual"),
   metadata: z.record(z.string(), z.any()).optional(),
 }).refine((value) => value.end.getTime() > value.start.getTime(), {

--- a/frontend/src/components/TimeZoneSelect.test.tsx
+++ b/frontend/src/components/TimeZoneSelect.test.tsx
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TimeZoneSelect } from "./TimeZoneSelect";
+import { useSettingsStore } from "@/stores/settingsStore";
+
+describe("TimeZoneSelect", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ favoriteTimeZones: [] });
+  });
+
+  it("finds a time zone by city alias and returns the matched place", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onPlaceSelect = vi.fn();
+    render(
+      <TimeZoneSelect
+        value="UTC"
+        onChange={onChange}
+        onPlaceSelect={onPlaceSelect}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.type(
+      screen.getByPlaceholderText("Search city or time zone…"),
+      "Metz",
+    );
+    await user.click(screen.getByText("Paris · Europe/Paris"));
+
+    expect(onChange).toHaveBeenCalledWith("Europe/Paris");
+    expect(onPlaceSelect).toHaveBeenCalledWith("Metz");
+  });
+
+  it("stores starred time zones as favorites", async () => {
+    const user = userEvent.setup();
+    render(<TimeZoneSelect value="UTC" onChange={() => {}} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.type(
+      screen.getByPlaceholderText("Search city or time zone…"),
+      "Bangkok",
+    );
+    await user.click(screen.getByRole("button", {
+      name: "Add Bangkok to favorites",
+    }));
+
+    expect(useSettingsStore.getState().favoriteTimeZones).toContain(
+      "Asia/Bangkok",
+    );
+  });
+});

--- a/frontend/src/components/TimeZoneSelect.tsx
+++ b/frontend/src/components/TimeZoneSelect.tsx
@@ -1,46 +1,210 @@
-import { useMemo } from "react";
+import { type MouseEvent, useMemo, useState } from "react";
+import { Check, ChevronsUpDown, Star } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
 import {
   BROWSER_TIME_ZONE,
   getBrowserTimeZone,
-  getSupportedTimeZones,
+  getTimeZoneSearchOptions,
+  type TimeZoneSearchOption,
 } from "@/lib/timeZones";
+import { useSettingsStore } from "@/stores/settingsStore";
 
 interface TimeZoneSelectProps {
   id?: string;
   value: string;
   onChange: (value: string) => void;
+  onPlaceSelect?: (place: string) => void;
   includeBrowser?: boolean;
   className?: string;
   disabled?: boolean;
+}
+
+function optionLabel(option: TimeZoneSearchOption) {
+  return option.timeZone === "UTC"
+    ? "UTC"
+    : `${option.city} · ${option.timeZone}`;
+}
+
+function matchedPlace(option: TimeZoneSearchOption, search: string) {
+  const normalized = search.trim().toLocaleLowerCase();
+  if (!normalized) return option.city;
+  return [option.city, ...option.aliases].find((place) =>
+    place.toLocaleLowerCase().includes(normalized)
+  ) ?? option.city;
 }
 
 export function TimeZoneSelect({
   id,
   value,
   onChange,
+  onPlaceSelect,
   includeBrowser = false,
   className = "",
   disabled = false,
 }: TimeZoneSelectProps) {
-  const timeZones = useMemo(getSupportedTimeZones, []);
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const options = useMemo(getTimeZoneSearchOptions, []);
   const browserTimeZone = getBrowserTimeZone();
+  const favoriteTimeZones = useSettingsStore((state) =>
+    state.favoriteTimeZones
+  );
+  const toggleFavoriteTimeZone = useSettingsStore((state) =>
+    state.toggleFavoriteTimeZone
+  );
+  const selected = options.find((option) => option.timeZone === value);
+  const favorites = favoriteTimeZones.flatMap((timeZone) => {
+    const option = options.find((item) => item.timeZone === timeZone);
+    return option ? [option] : [];
+  });
+
+  const selectOption = (option: TimeZoneSearchOption) => {
+    onChange(option.timeZone);
+    onPlaceSelect?.(matchedPlace(option, search));
+    setOpen(false);
+    setSearch("");
+  };
+
+  const toggleFavorite = (
+    event: MouseEvent<HTMLButtonElement>,
+    timeZone: string,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    toggleFavoriteTimeZone(timeZone);
+  };
+
+  const renderOption = (
+    option: TimeZoneSearchOption,
+    section: "favorite" | "all",
+  ) => {
+    const isFavorite = favoriteTimeZones.includes(option.timeZone);
+    return (
+      <CommandItem
+        key={`${section}:${option.timeZone}`}
+        value={`${section} ${option.searchValue}`}
+        onSelect={() => selectOption(option)}
+        className="group"
+      >
+        <Check
+          className={cn(
+            "mr-1 h-4 w-4",
+            value === option.timeZone ? "opacity-100" : "opacity-0",
+          )}
+        />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate">{optionLabel(option)}</span>
+          {option.aliases.length > 0 && (
+            <span className="block truncate text-xs text-muted-foreground">
+              Also: {option.aliases.join(", ")}
+            </span>
+          )}
+        </span>
+        <button
+          type="button"
+          aria-label={`${isFavorite ? "Remove" : "Add"} ${option.city} ${
+            isFavorite ? "from" : "to"
+          } favorites`}
+          title={isFavorite ? "Remove from favorites" : "Add to favorites"}
+          className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+          onMouseDown={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+          }}
+          onClick={(event) => toggleFavorite(event, option.timeZone)}
+        >
+          <Star className={cn("h-4 w-4", isFavorite && "fill-current")} />
+        </button>
+      </CommandItem>
+    );
+  };
+
+  const displayLabel = value === BROWSER_TIME_ZONE
+    ? `Current device (${browserTimeZone})`
+    : selected
+    ? optionLabel(selected)
+    : value;
 
   return (
-    <select
-      id={id}
-      value={value}
-      disabled={disabled}
-      onChange={(event) => onChange(event.target.value)}
-      className={`flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) setSearch("");
+      }}
     >
-      {includeBrowser && (
-        <option value={BROWSER_TIME_ZONE}>
-          Current device ({browserTimeZone})
-        </option>
-      )}
-      {timeZones.map((timeZone) => (
-        <option key={timeZone} value={timeZone}>{timeZone}</option>
-      ))}
-    </select>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className={cn("w-full justify-between font-normal", className)}
+        >
+          <span className="truncate">{displayLabel}</span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[380px] p-0">
+        <Command>
+          <CommandInput
+            value={search}
+            onValueChange={setSearch}
+            placeholder="Search city or time zone…"
+          />
+          <CommandList>
+            <CommandEmpty>No city or time zone found.</CommandEmpty>
+            {includeBrowser && (
+              <CommandGroup heading="Device">
+                <CommandItem
+                  value={`device current ${browserTimeZone}`}
+                  onSelect={() => {
+                    onChange(BROWSER_TIME_ZONE);
+                    setOpen(false);
+                    setSearch("");
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-1 h-4 w-4",
+                      value === BROWSER_TIME_ZONE ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  Current device · {browserTimeZone}
+                </CommandItem>
+              </CommandGroup>
+            )}
+            {favorites.length > 0 && (
+              <>
+                <CommandGroup heading="Favorites">
+                  {favorites.map((option) => renderOption(option, "favorite"))}
+                </CommandGroup>
+                <CommandSeparator />
+              </>
+            )}
+            <CommandGroup heading="All cities and time zones">
+              {options.map((option) => renderOption(option, "all"))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/frontend/src/components/timeline/TimelineTimeZoneControl.tsx
+++ b/frontend/src/components/timeline/TimelineTimeZoneControl.tsx
@@ -15,6 +15,7 @@ import { useTimelineTimeZone } from "@/hooks/useTimelineTimeZone";
 import {
   getPeriodId,
   getShortTimeZoneName,
+  getTimeZoneSearchOptions,
   type TimelineTimeZonePeriod,
 } from "@/lib/timeZones";
 
@@ -49,6 +50,9 @@ export function TimelineTimeZoneControl({
   const setOverride = useSettingsStore(
     (state) => state.setTimelineTimeZoneOverride,
   );
+  const favoriteTimeZones = useSettingsStore((state) =>
+    state.favoriteTimeZones
+  );
   const { activeTimeZone, browserTimeZone, periods } = useTimelineTimeZone();
   const createPeriod = useTimelineTimeZoneStore((state) => state.createPeriod);
   const deletePeriod = useTimelineTimeZoneStore((state) => state.deletePeriod);
@@ -57,6 +61,13 @@ export function TimelineTimeZoneControl({
   const [periodTimeZone, setPeriodTimeZone] = useState(activeTimeZone);
   const [location, setLocation] = useState("");
   const [saved, setSaved] = useState(false);
+  const favoriteOptions = useMemo(() => {
+    const options = getTimeZoneSearchOptions();
+    return favoriteTimeZones.flatMap((timeZone) => {
+      const option = options.find((item) => item.timeZone === timeZone);
+      return option ? [option] : [];
+    });
+  }, [favoriteTimeZones]);
 
   const selectedPeriods = useMemo(() => {
     if (!selectionStart || !selectionEnd) return periods;
@@ -105,7 +116,7 @@ export function TimelineTimeZoneControl({
           </span>
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-[380px] space-y-5">
+      <PopoverContent align="end" className="w-[420px] space-y-5">
         <div className="space-y-1">
           <h3 className="font-medium">Timeline time zone</h3>
           <p className="text-xs text-muted-foreground">
@@ -143,8 +154,36 @@ export function TimelineTimeZoneControl({
           <TimeZoneSelect
             value={periodTimeZone}
             onChange={setPeriodTimeZone}
+            onPlaceSelect={(place) => {
+              if (!location.trim()) setLocation(place);
+            }}
             disabled={!selectionStart || !selectionEnd}
           />
+          {favoriteOptions.length > 0 && (
+            <div className="space-y-1.5">
+              <p className="text-xs text-muted-foreground">Quick favorites</p>
+              <div className="flex flex-wrap gap-1.5">
+                {favoriteOptions.map((option) => (
+                  <Button
+                    key={option.timeZone}
+                    type="button"
+                    size="sm"
+                    variant={periodTimeZone === option.timeZone
+                      ? "default"
+                      : "outline"}
+                    className="h-7 px-2 text-xs"
+                    disabled={!selectionStart || !selectionEnd}
+                    onClick={() => {
+                      setPeriodTimeZone(option.timeZone);
+                      if (!location.trim()) setLocation(option.city);
+                    }}
+                  >
+                    {option.city}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          )}
           <div className="relative">
             <MapPin className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
             <Input

--- a/frontend/src/lib/timeZones.test.ts
+++ b/frontend/src/lib/timeZones.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   findTimeZonePeriod,
   getTimelinePresetRange,
+  getTimeZoneSearchOptions,
   getZonedDateParts,
   isValidTimeZone,
   type TimelineTimeZonePeriod,
@@ -28,6 +29,14 @@ describe("timeline time zones", () => {
     expect(isValidTimeZone("Europe/Paris")).toBe(true);
     expect(isValidTimeZone("Asia/Tbilisi")).toBe(true);
     expect(isValidTimeZone("Mars/Olympus_Mons")).toBe(false);
+  });
+
+  it("indexes city aliases for time-zone search", () => {
+    const paris = getTimeZoneSearchOptions().find((option) =>
+      option.timeZone === "Europe/Paris"
+    );
+    expect(paris?.searchValue).toContain("Metz");
+    expect(paris?.city).toBe("Paris");
   });
 
   it("uses the newest overlapping period", () => {

--- a/frontend/src/lib/timeZones.ts
+++ b/frontend/src/lib/timeZones.ts
@@ -57,6 +57,55 @@ const FALLBACK_TIME_ZONES = [
   "Pacific/Auckland",
 ];
 
+const TIME_ZONE_CITY_ALIASES: Record<string, string[]> = {
+  "America/Los_Angeles": ["San Francisco", "San Diego", "Seattle"],
+  "America/New_York": ["Boston", "Miami", "Washington DC"],
+  "America/Toronto": ["Ottawa"],
+  "America/Mexico_City": ["Mexico City"],
+  "America/Sao_Paulo": ["São Paulo"],
+  "Europe/London": ["Belfast", "Edinburgh", "Manchester"],
+  "Europe/Paris": ["Metz", "Nancy", "Lyon", "Strasbourg"],
+  "Europe/Berlin": ["Hamburg", "Munich", "Frankfurt"],
+  "Europe/Amsterdam": ["Rotterdam", "The Hague"],
+  "Europe/Moscow": ["Saint Petersburg"],
+  "Asia/Tbilisi": ["Batumi", "Kutaisi"],
+  "Asia/Dubai": ["Abu Dhabi"],
+  "Asia/Calcutta": ["Kolkata", "Delhi", "Mumbai", "Bengaluru"],
+  "Asia/Kolkata": ["Delhi", "Mumbai", "Bengaluru"],
+  "Asia/Bangkok": ["Chiang Mai", "Phuket"],
+  "Asia/Tokyo": ["Osaka", "Kyoto"],
+  "Australia/Sydney": ["Canberra"],
+  "Pacific/Auckland": ["Wellington"],
+};
+
+export interface TimeZoneSearchOption {
+  timeZone: string;
+  city: string;
+  aliases: string[];
+  searchValue: string;
+}
+
+function humanizeTimeZonePart(value: string): string {
+  return value.replaceAll("_", " ");
+}
+
+export function getTimeZoneSearchOptions(): TimeZoneSearchOption[] {
+  return getSupportedTimeZones().map((timeZone) => {
+    const parts = timeZone.split("/");
+    const city = timeZone === "UTC"
+      ? "UTC"
+      : humanizeTimeZonePart(parts.at(-1) ?? timeZone);
+    const region = parts.length > 1 ? humanizeTimeZonePart(parts[0]) : "";
+    const aliases = TIME_ZONE_CITY_ALIASES[timeZone] ?? [];
+    return {
+      timeZone,
+      city,
+      aliases,
+      searchValue: [city, timeZone, region, ...aliases].join(" "),
+    };
+  });
+}
+
 export function getSupportedTimeZones(): string[] {
   const intl = Intl as typeof Intl & {
     supportedValuesOf?: (key: "timeZone") => string[];

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -27,6 +27,7 @@ interface SettingsState {
   defaultTimeZone: DefaultTimeZone;
   timelineTimeZoneMode: TimelineTimeZoneMode;
   timelineTimeZoneOverride: string;
+  favoriteTimeZones: string[];
   transcriptThresholdHours: number;
   preferredAudioDeviceId: string | null;
   echoCancellation: boolean;
@@ -43,6 +44,7 @@ interface SettingsState {
   setDefaultTimeZone: (timeZone: DefaultTimeZone) => void;
   setTimelineTimeZoneMode: (mode: TimelineTimeZoneMode) => void;
   setTimelineTimeZoneOverride: (timeZone: string) => void;
+  toggleFavoriteTimeZone: (timeZone: string) => void;
   setTranscriptThresholdHours: (hours: number) => void;
   setPreferredAudioDeviceId: (deviceId: string | null) => void;
   setEchoCancellation: (enabled: boolean) => void;
@@ -75,6 +77,7 @@ export const useSettingsStore = create<SettingsState>()(
       defaultTimeZone: BROWSER_TIME_ZONE,
       timelineTimeZoneMode: "contextual",
       timelineTimeZoneOverride: "UTC",
+      favoriteTimeZones: [],
       transcriptThresholdHours: DEFAULT_TRANSCRIPT_THRESHOLD_HOURS,
       preferredAudioDeviceId: null,
       echoCancellation: true,
@@ -92,6 +95,12 @@ export const useSettingsStore = create<SettingsState>()(
       setTimelineTimeZoneMode: (mode) => set({ timelineTimeZoneMode: mode }),
       setTimelineTimeZoneOverride: (timeZone) =>
         set({ timelineTimeZoneOverride: timeZone }),
+      toggleFavoriteTimeZone: (timeZone) =>
+        set((state) => ({
+          favoriteTimeZones: state.favoriteTimeZones.includes(timeZone)
+            ? state.favoriteTimeZones.filter((item) => item !== timeZone)
+            : [...state.favoriteTimeZones, timeZone],
+        })),
       setTranscriptThresholdHours: (hours) =>
         set({ transcriptThresholdHours: hours }),
       setPreferredAudioDeviceId: (deviceId) =>
@@ -112,6 +121,7 @@ export const useSettingsStore = create<SettingsState>()(
           defaultTimeZone: BROWSER_TIME_ZONE,
           timelineTimeZoneMode: "contextual",
           timelineTimeZoneOverride: "UTC",
+          favoriteTimeZones: [],
           transcriptThresholdHours: DEFAULT_TRANSCRIPT_THRESHOLD_HOURS,
           preferredAudioDeviceId: null,
           echoCancellation: true,

--- a/frontend/src/stores/timelineTimeZoneStore.test.ts
+++ b/frontend/src/stores/timelineTimeZoneStore.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { callResource } from "@/lib/api";
+import { useTimelineTimeZoneStore } from "./timelineTimeZoneStore";
+
+vi.mock("@/lib/api", () => ({ callResource: vi.fn() }));
+
+const mockCallResource = vi.mocked(callResource);
+
+describe("timelineTimeZoneStore", () => {
+  beforeEach(() => {
+    mockCallResource.mockReset();
+    useTimelineTimeZoneStore.setState({
+      periods: [],
+      saving: false,
+      error: null,
+    });
+  });
+
+  it("omits an empty location instead of serializing it as null", async () => {
+    mockCallResource.mockResolvedValue({
+      _id: "period-1",
+      start: new Date("2026-07-28T10:00:00.000Z"),
+      end: new Date("2026-07-28T11:00:00.000Z"),
+      timeZone: "Asia/Bangkok",
+      source: "manual",
+    });
+
+    await useTimelineTimeZoneStore.getState().createPeriod({
+      start: new Date("2026-07-28T10:00:00.000Z"),
+      end: new Date("2026-07-28T11:00:00.000Z"),
+      timeZone: "Asia/Bangkok",
+      location: undefined,
+    });
+
+    const request = mockCallResource.mock.calls[0]?.[1] as {
+      period: Record<string, unknown>;
+    };
+    expect(request.period).not.toHaveProperty("location");
+  });
+});

--- a/frontend/src/stores/timelineTimeZoneStore.ts
+++ b/frontend/src/stores/timelineTimeZoneStore.ts
@@ -60,9 +60,15 @@ export const useTimelineTimeZoneStore = create<TimelineTimeZoneState>(
     createPeriod: async (period) => {
       set({ saving: true, error: null });
       try {
+        const normalizedPeriod = {
+          ...period,
+          ...(period.location ? { location: period.location } : {}),
+          source: period.source ?? "manual",
+        };
+        if (!period.location) delete normalizedPeriod.location;
         const created = await callResource("timeline-timezones", {
           action: "create",
-          period: { ...period, source: period.source ?? "manual" },
+          period: normalizedPeriod,
         }) as TimelineTimeZonePeriod;
         set((state) => ({
           periods: [...state.periods, created].sort(


### PR DESCRIPTION
## Summary
- fix period saves when the optional place field is empty
- replace the native time-zone select with searchable city/IANA-zone lookup
- add persisted favorite time zones, favorites-first results, and quick period buttons
- map useful city aliases such as Metz to Europe/Paris

## Verification
- backend timezone resource tests: 4 passed
- focused frontend tests: 9 passed
- targeted Deno check and lint passed
- production frontend Docker build passed