### PR TITLE
WIP: OpenRouter batch workflow

### DIFF
--- a/backend/app/lib/jobs/queue.ts
+++ b/backend/app/lib/jobs/queue.ts
@@ -73,7 +73,7 @@ export async function enqueueJob(
   // Resolve the selected prompt document at enqueue time. Each job keeps a
   // reproducible snapshot while config remains the source of truth for new jobs.
   const summarizationDefaults: SummarizationDefaults = {};
-  if (data.type === "summarization") {
+  if (data.type === "summarization" || data.type === "openrouter_batch") {
     const config = await mongo({
       action: "findOne",
       collection: "configs",
@@ -174,6 +174,14 @@ export async function enqueueJob(
         defaultOverrides,
         summarizationDefaults,
       );
+    } else if (data.type === "openrouter_batch") {
+      // The batch pilot uses the exact configured summary prompt, but has a
+      // fixed model. Snapshot this here so its eventual result remains
+      // reproducible even if settings change during OpenRouter's 24h window.
+      if (mergedData.prompt === undefined && summarizationDefaults.prompt) {
+        mergedData.prompt = summarizationDefaults.prompt.text;
+        mergedData.promptName = summarizationDefaults.prompt.name;
+      }
     } else if (defaultOverrides) {
       for (const [key, value] of Object.entries(defaultOverrides)) {
         if (!(key in mergedData) || mergedData[key] === undefined) {

--- a/backend/app/lib/jobs/service-health.shared.ts
+++ b/backend/app/lib/jobs/service-health.shared.ts
@@ -31,6 +31,8 @@ export const JOB_SERVICE_DEPENDENCIES: Record<string, ExternalServiceId[]> = {
   conversation_extractor: ["llm"],
   summarization: ["llm"],
   tagger: ["llm"],
+  openrouter_batch: ["llm"],
+  openrouter_batch_poll: ["llm"],
 };
 
 export function getJobServiceDependencies(

--- a/backend/app/lib/llm/resource.server.test.ts
+++ b/backend/app/lib/llm/resource.server.test.ts
@@ -114,3 +114,59 @@ Deno.test("OpenRouter generation metadata supplies the final completion cost", a
     restoreEnv(previousEnv);
   }
 });
+
+Deno.test({
+  name: "OpenRouter Batch API submits, polls, and cancels through its beta endpoint",
+  // The shared server-config fixture starts a process watcher. The existing
+  // resource tests exercise the same fixture; this test is scoped to HTTP
+  // request construction and restores every process-global mock itself.
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+  const previousEnv = new Map(
+    ENV_NAMES.map((name) => [name, Deno.env.get(name)]),
+  );
+  const originalFetch = globalThis.fetch;
+  const calls: Array<{ url: string; method: string; body?: string }> = [];
+  Deno.env.set("OPENAI_BASE_URL", "https://openrouter.ai/api/v1");
+  Deno.env.set("OPENAI_API_KEY", "test-key");
+  Deno.env.set("OPENAI_MODEL", "deepseek/deepseek-v4-flash");
+
+  globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({ url, method: init?.method ?? "GET", body: init?.body?.toString() });
+    if (url === "https://openrouter.ai/api/beta/batches") {
+      return new Response(JSON.stringify({ id: "batch-1", status: "validating" }), { status: 202 });
+    }
+    if (url === "https://openrouter.ai/api/beta/batches/batch-1") {
+      return new Response(JSON.stringify({ id: "batch-1", status: "in_progress" }));
+    }
+    if (url === "https://openrouter.ai/api/beta/batches/batch-1/cancel") {
+      return new Response(JSON.stringify({ id: "batch-1", status: "cancelling" }));
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  };
+
+  try {
+    const resource = new LLMResource();
+    await resource.use({
+      action: "batch_submit",
+      endpoint: "/v1/chat/completions",
+      model: "deepseek/deepseek-v4-flash",
+      requests: [{ custom_id: "summary:1", body: { messages: [] } }],
+    }, {} as never);
+    await resource.use({ action: "batch_get", batchId: "batch-1" }, {} as never);
+    await resource.use({ action: "batch_cancel", batchId: "batch-1" }, {} as never);
+
+    expect(calls.map((call) => [call.method, call.url])).toEqual([
+      ["POST", "https://openrouter.ai/api/beta/batches"],
+      ["GET", "https://openrouter.ai/api/beta/batches/batch-1"],
+      ["POST", "https://openrouter.ai/api/beta/batches/batch-1/cancel"],
+    ]);
+    expect(calls[0].body?.startsWith('{"endpoint":"/v1/chat/completions","model"')).toBe(true);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreEnv(previousEnv);
+  }
+  },
+});

--- a/backend/app/lib/llm/resource.server.ts
+++ b/backend/app/lib/llm/resource.server.ts
@@ -87,12 +87,45 @@ const chatCompletionRequestSchema = z.object({
     .optional(),
 });
 
+const batchRequestItemSchema = z.object({
+  custom_id: z.string().trim().min(1).max(256),
+  // OpenRouter validates the endpoint-specific body. Keeping this permissive
+  // lets the resource support all documented batch API skins without leaking
+  // batch transport details into workers.
+  body: z.record(z.string(), z.unknown()),
+});
+
+const batchSubmitRequestSchema = z.object({
+  action: z.literal("batch_submit"),
+  endpoint: z.enum([
+    "/v1/chat/completions",
+    "/v1/responses",
+    "/v1/messages",
+    "/v1/embeddings",
+  ]),
+  model: z.string().trim().min(1),
+  requests: z.array(batchRequestItemSchema).min(1).max(100),
+});
+
+const batchGetRequestSchema = z.object({
+  action: z.literal("batch_get"),
+  batchId: z.string().trim().min(1),
+});
+
+const batchCancelRequestSchema = z.object({
+  action: z.literal("batch_cancel"),
+  batchId: z.string().trim().min(1),
+});
+
 const listModelsRequestSchema = z.object({
   action: z.literal("list"),
 });
 
 const llmRequestSchema = z.discriminatedUnion("action", [
   chatCompletionRequestSchema,
+  batchSubmitRequestSchema,
+  batchGetRequestSchema,
+  batchCancelRequestSchema,
   listModelsRequestSchema,
 ]);
 
@@ -191,6 +224,38 @@ function isOpenRouterPromptCachingBaseUrl(baseUrl: string): boolean {
   } catch {
     return false;
   }
+}
+
+function getOpenRouterBatchBaseUrl(baseUrl: string): string | null {
+  try {
+    const url = new URL(baseUrl);
+    if (url.hostname !== "openrouter.ai") return null;
+    return `${url.protocol}//${url.host}/api/beta/batches`;
+  } catch {
+    return null;
+  }
+}
+
+async function readOpenRouterBatchResponse(response: Response): Promise<any> {
+  const text = await response.text();
+  let parsed: unknown = null;
+  try {
+    parsed = text ? JSON.parse(text) : null;
+  } catch {
+    // Preserve the useful provider body in a bounded error below.
+  }
+  if (!response.ok) {
+    const detail = typeof parsed === "object" && parsed !== null
+      ? JSON.stringify(parsed)
+      : text;
+    throw new Error(
+      `OpenRouter Batch API error (${response.status}): ${detail.slice(0, 1000)}`,
+    );
+  }
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("OpenRouter Batch API returned an invalid JSON response");
+  }
+  return parsed;
 }
 
 export class LLMResource implements Resource<LLMRequest, LLMResponse> {
@@ -328,6 +393,52 @@ export class LLMResource implements Resource<LLMRequest, LLMResponse> {
 
     try {
       switch (input.action) {
+        case "batch_submit":
+        case "batch_get":
+        case "batch_cancel": {
+          const provider = await this.getInferenceProvider();
+          if (!provider) {
+            throw new Error(
+              "Inference provider not configured. Please configure it in server settings.",
+            );
+          }
+          const batchBaseUrl = getOpenRouterBatchBaseUrl(provider.baseUrl);
+          if (!batchBaseUrl) {
+            throw new Error(
+              "OpenRouter Batch API requires an active provider with base URL https://openrouter.ai/api/v1",
+            );
+          }
+
+          let url = batchBaseUrl;
+          let method = "GET";
+          let body: Record<string, unknown> | undefined;
+          if (input.action === "batch_submit") {
+            method = "POST";
+            // Property order is intentional: OpenRouter stream-parses batch
+            // input and requires endpoint/model before requests.
+            body = {
+              endpoint: input.endpoint,
+              model: this.resolveModelAlias(input.model, provider),
+              requests: input.requests,
+            };
+          } else {
+            url = `${batchBaseUrl}/${encodeURIComponent(input.batchId)}`;
+            if (input.action === "batch_cancel") {
+              method = "POST";
+              url += "/cancel";
+            }
+          }
+
+          const batchResponse = await fetch(url, {
+            method,
+            headers: {
+              "Content-Type": "application/json",
+              "Authorization": `Bearer ${provider.apiKey}`,
+            },
+            ...(body ? { body: JSON.stringify(body) } : {}),
+          });
+          return await readOpenRouterBatchResponse(batchResponse);
+        }
         case "completions": {
           const {
             action,

--- a/backend/app/lib/resources/worker.ts
+++ b/backend/app/lib/resources/worker.ts
@@ -15,6 +15,7 @@ import {
   getExternalServicesHealth,
 } from "@/lib/jobs/service-health.ts";
 import { cancelRunningJob } from "@/lib/jobs/processor.ts";
+import { LLMResource } from "@/lib/llm/resource.server.ts";
 
 const UpdateProgressSchema = z.object({
   action: z.literal("progressUpdate"),
@@ -79,6 +80,24 @@ const DismissFailedJobSchema = z.object({
 const GetJobSchema = z.object({
   action: z.literal("get"),
   id: z.string(),
+});
+
+const ListOpenRouterBatchesSchema = z.object({
+  action: z.literal("openrouter_batch_list"),
+  limit: z.number().int().min(1).max(100).default(25),
+});
+
+const CancelOpenRouterBatchSchema = z.object({
+  action: z.literal("openrouter_batch_cancel"),
+  id: z.string(),
+});
+
+const GetOpenRouterBatchControlSchema = z.object({
+  action: z.literal("openrouter_batch_control"),
+});
+
+const ResumeOpenRouterBatchSchema = z.object({
+  action: z.literal("openrouter_batch_resume"),
 });
 
 interface JobModelProvenanceEntry {
@@ -224,6 +243,10 @@ const RequestSchema = z.union([
   CancelJobSchema,
   DismissFailedJobSchema,
   GetJobSchema,
+  ListOpenRouterBatchesSchema,
+  CancelOpenRouterBatchSchema,
+  GetOpenRouterBatchControlSchema,
+  ResumeOpenRouterBatchSchema,
   EnqueueJobSchema,
   SchemasSchema,
   PauseWorkerSchema,
@@ -417,6 +440,14 @@ export class JobsResource implements Resource<WorkerProgressRequest, any> {
     switch (input.action) {
       case "get":
         return this.get(input, auth);
+      case "openrouter_batch_list":
+        return this.listOpenRouterBatches(input, auth);
+      case "openrouter_batch_cancel":
+        return this.cancelOpenRouterBatch(input, auth);
+      case "openrouter_batch_control":
+        return this.getOpenRouterBatchControl(auth);
+      case "openrouter_batch_resume":
+        return this.resumeOpenRouterBatch(auth);
       case "enqueue":
         return this.enqueue(input, auth);
       case "cancel":
@@ -624,6 +655,115 @@ export class JobsResource implements Resource<WorkerProgressRequest, any> {
       success: true,
       jobId: job.id,
     };
+  }
+
+  private async listOpenRouterBatches(
+    input: z.infer<typeof ListOpenRouterBatchesSchema>,
+    auth: Auth,
+  ) {
+    const mongo = await getMongoResource(auth);
+    const batches = await mongo({
+      action: "find",
+      collection: "openrouter_batches",
+      query: {},
+      options: {
+        sort: { submittedAt: -1 },
+        limit: input.limit,
+        projection: {
+          batchId: 1,
+          ownerJobId: 1,
+          task: 1,
+          model: 1,
+          status: 1,
+          requestCounts: 1,
+          usage: 1,
+          submittedAt: 1,
+          completedAt: 1,
+          importedAt: 1,
+          importCounts: 1,
+          updatedAt: 1,
+        },
+      },
+    });
+    return batches.map((batch: any) => ({
+      id: batch._id?.toString(),
+      ...batch,
+      _id: undefined,
+    }));
+  }
+
+  private async cancelOpenRouterBatch(
+    input: z.infer<typeof CancelOpenRouterBatchSchema>,
+    auth: Auth,
+  ) {
+    const mongo = await getMongoResource(auth);
+    const batches = await mongo({
+      action: "find",
+      collection: "openrouter_batches",
+      query: { _id: new ObjectId(input.id) },
+      options: { limit: 1 },
+    });
+    const batch = batches[0];
+    if (!batch) throw new Error(`OpenRouter batch ${input.id} not found`);
+    if (["completed", "failed", "expired", "cancelled"].includes(batch.status)) {
+      return { success: true, cancelled: false, status: batch.status };
+    }
+
+    const remote = await new LLMResource().use({
+      action: "batch_cancel",
+      batchId: batch.batchId,
+    }, auth) as Record<string, unknown>;
+    const now = new Date();
+    await mongo({
+      action: "updateOne",
+      collection: "openrouter_batches",
+      query: { _id: batch._id },
+      update: {
+        $set: {
+          status: remote.status ?? "cancelling",
+          cancellationRequestedAt: now,
+          updatedAt: now,
+        },
+      },
+    });
+    await mongo({
+      action: "updateMany",
+      collection: "objects",
+      query: { "_summarizationClaim.jobId": batch.ownerJobId },
+      update: { $unset: { _summarizationClaim: "" } },
+    });
+    return { success: true, cancelled: true, batchId: batch.batchId, status: remote.status };
+  }
+
+  private async getOpenRouterBatchControl(auth: Auth) {
+    const mongo = await getMongoResource(auth);
+    const control = await mongo({
+      action: "findOne",
+      collection: "openrouter_batch_control",
+      query: { _id: "openrouter_batch" },
+    });
+    return {
+      paused: Boolean(control?.paused),
+      reason: control?.reason,
+      pausedAt: control?.pausedAt,
+      resumedAt: control?.resumedAt,
+    };
+  }
+
+  private async resumeOpenRouterBatch(auth: Auth) {
+    const mongo = await getMongoResource(auth);
+    const now = new Date();
+    await mongo({
+      action: "updateOne",
+      collection: "openrouter_batch_control",
+      query: { _id: "openrouter_batch" },
+      update: {
+        $set: { paused: false, resumedAt: now, updatedAt: now },
+        $unset: { reason: "", pausedAt: "" },
+      },
+      options: { upsert: true },
+    });
+    return { success: true, paused: false, resumedAt: now };
   }
 
   private async cancel(input: z.infer<typeof CancelJobSchema>, auth: Auth) {

--- a/backend/workers/openrouter_batch.test.ts
+++ b/backend/workers/openrouter_batch.test.ts
@@ -1,0 +1,20 @@
+import { expect } from "@std/expect";
+import { OPENROUTER_BATCH_MODEL, schema } from "./openrouter_batch.ts";
+
+Deno.test("OpenRouter batch pilot is fixed to DeepSeek V4 Flash and bounded to 100 items", () => {
+  const parsed = schema.parse({
+    type: "openrouter_batch",
+    action: "dry_run",
+    prompt: "Summarize the conversation.",
+  });
+  expect(parsed.model).toBe(OPENROUTER_BATCH_MODEL);
+  expect(parsed.limit).toBe(100);
+
+  const tooMany = schema.safeParse({
+    type: "openrouter_batch",
+    action: "submit",
+    prompt: "Summarize the conversation.",
+    objectIds: Array.from({ length: 101 }, (_, index) => `${index}`),
+  });
+  expect(tooMany.success).toBe(false);
+});

--- a/backend/workers/openrouter_batch.ts
+++ b/backend/workers/openrouter_batch.ts
@@ -1,0 +1,405 @@
+import { createHash } from "node:crypto";
+import { ObjectId } from "bson";
+import type { Job } from "bullmq";
+import { z } from "zod";
+import { callResource } from "@myceliasdk/resources.ts";
+import type { JobCapability } from "@/lib/jobs/job-registry.ts";
+import type { JobData, JobResult } from "@/lib/jobs/types.ts";
+import { getChatCompletionText } from "@/lib/llm/completion-response.ts";
+import { getSummaryCompletionOptions } from "@/lib/llm/completion-options.ts";
+import { createPromptCacheSessionId } from "@/lib/llm/prompt-cache-session.ts";
+import {
+  buildPromptFromTranscripts,
+  buildSummarySourceRefs,
+  claimConversation,
+  createLLMSummaryEntry,
+  getConversationRange,
+  getConversationSourceContext,
+  hasNoSummaries,
+  releaseClaim,
+  updateObjectSummaries,
+  type SummarySourceRefs,
+} from "./summarization.ts";
+
+export const OPENROUTER_BATCH_MODEL = "deepseek/deepseek-v4-flash";
+const BATCH_LIMIT = 100;
+const BATCH_CLAIM_HOLD_MS = 25 * 60 * 60 * 1000;
+const ACTIVE_BATCH_STATES = ["validating", "in_progress", "finalizing", "cancelling"];
+const TERMINAL_BATCH_STATES = ["completed", "failed", "expired", "cancelled"];
+const PROVIDER_CONTROL_ID = "openrouter_batch";
+
+export const schema = z.object({
+  type: z.literal("openrouter_batch"),
+  action: z.enum(["dry_run", "submit"]).default("dry_run"),
+  task: z.literal("summarization").default("summarization"),
+  // Keep the production default pinned to DeepSeek, but allow the explicit
+  // GPT-4o compatibility probe without changing the normal worker default.
+  model: z.enum([OPENROUTER_BATCH_MODEL, "openai/gpt-4o"])
+    .default(OPENROUTER_BATCH_MODEL),
+  prompt: z.string().min(1).optional().describe(
+    "Leave empty to snapshot the currently configured summary prompt",
+  ),
+  promptName: z.string().optional(),
+  limit: z.number().int().min(1).max(BATCH_LIMIT).default(BATCH_LIMIT),
+  objectIds: z.array(z.string()).max(BATCH_LIMIT).optional(),
+});
+
+const pollSchema = z.object({ type: z.literal("openrouter_batch_poll") });
+
+type OpenRouterBatchJobData = z.infer<typeof schema>;
+
+type BatchItem = {
+  customId: string;
+  objectId: string;
+  sourceRefs: SummarySourceRefs;
+  requestHash: string;
+};
+
+function requestHash(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function itemId(objectId: string, hash: string): string {
+  return `summary:${objectId}:${hash.slice(0, 16)}`;
+}
+
+function isProviderWideError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /OpenRouter Batch API error \((?:401|403|404|408|409|429|5\d{2})\)/.test(message)
+    || /OpenRouter Batch API returned an invalid JSON response/.test(message);
+}
+
+async function findTargets(
+  data: OpenRouterBatchJobData,
+  objects: (input: any) => Promise<any>,
+) {
+  if (data.objectIds?.length) {
+    return await objects({
+      action: "list",
+      filters: {
+        _id: { $in: data.objectIds.map((id) => new ObjectId(id)) },
+        isConversation: true,
+      },
+      options: { limit: data.limit },
+    });
+  }
+  return await objects({
+    action: "list",
+    filters: {
+      isConversation: true,
+      "summaries.0": { $exists: false },
+      $or: [
+        { "_summarizationFailure.status": { $ne: "failed" } },
+        { "_summarizationFailure.retryAfter": { $exists: false } },
+        { "_summarizationFailure.retryAfter": { $lte: new Date().toISOString() } },
+      ],
+    },
+    options: { limit: data.limit, sort: { updatedAt: -1 } },
+  });
+}
+
+async function prepareItems(
+  jobId: string,
+  data: OpenRouterBatchJobData,
+  jwt: string,
+  myceliaUrl: string,
+): Promise<{ requests: Array<{ custom_id: string; body: Record<string, unknown> }>; items: BatchItem[]; skipped: number }> {
+  const mongo = (input: any) => callResource("mongo", input, { jwt, myceliaUrl });
+  const objects = (input: any) => callResource("objects", input, { jwt, myceliaUrl });
+  const targets = await findTargets(data, objects);
+  const requests: Array<{ custom_id: string; body: Record<string, unknown> }> = [];
+  const items: BatchItem[] = [];
+  let skipped = 0;
+
+  for (const target of targets) {
+    if (!hasNoSummaries(target)) {
+      skipped++;
+      continue;
+    }
+    const objectId = target._id?.toString();
+    const range = getConversationRange(target);
+    if (!objectId || !range) {
+      skipped++;
+      continue;
+    }
+    const transcripts = await mongo({
+      action: "find",
+      collection: "transcriptions",
+      query: { start: { $lte: range.end }, end: { $gte: range.start } },
+      options: { sort: { start: 1 } },
+    }) as any[];
+    if (!transcripts?.length) {
+      skipped++;
+      continue;
+    }
+    const promptText = buildPromptFromTranscripts(transcripts);
+    const body: Record<string, unknown> = {
+      session_id: createPromptCacheSessionId("summarization-body", {
+        system: data.prompt,
+        responseFormat: getSummaryCompletionOptions(data.model),
+      }),
+      ...getSummaryCompletionOptions(data.model),
+      messages: [
+        { role: "system", content: data.prompt },
+        { role: "user", content: promptText },
+      ],
+    };
+    // Include the optimistic object version in the durable identity so a
+    // changed conversation cannot be mistaken for an earlier batch request.
+    const hash = requestHash({ body, objectVersion: target.version ?? 0 });
+    const customId = itemId(objectId, hash);
+    if (!await claimConversation(objectId, jobId, jwt, myceliaUrl, {
+      kind: "openrouter_batch",
+      // 24h provider completion window + a bounded margin for the next poll.
+      holdUntil: new Date(Date.now() + BATCH_CLAIM_HOLD_MS),
+    })) {
+      skipped++;
+      continue;
+    }
+    requests.push({ custom_id: customId, body });
+    items.push({
+      customId,
+      objectId,
+      requestHash: hash,
+      sourceRefs: buildSummarySourceRefs(
+        transcripts,
+        range.start,
+        range.end,
+        getConversationSourceContext(target),
+      ),
+    });
+  }
+  return { requests, items, skipped };
+}
+
+async function submit(job: Job<JobData>): Promise<JobResult> {
+  const data = job.data as OpenRouterBatchJobData;
+  if (!data.prompt) {
+    throw new Error(
+      "OpenRouter batch needs a configured summarization prompt before submission",
+    );
+  }
+  const promptVersion = requestHash({ prompt: data.prompt }).slice(0, 16);
+  const jwt = Deno.env.get("MYCELIA_JWT")!;
+  const myceliaUrl = Deno.env.get("MYCELIA_URL")!;
+  const jobId = job.id ?? "unknown";
+  const mongo = (input: any) => callResource("mongo", input, { jwt, myceliaUrl });
+  const control = await mongo({
+    action: "findOne",
+    collection: "openrouter_batch_control",
+    query: { _id: PROVIDER_CONTROL_ID },
+  }) as Record<string, unknown> | null;
+  if (control?.paused) {
+    throw new Error(
+      `OpenRouter batch submissions are paused after a provider-wide error: ${String(control.reason ?? "unknown error")}`,
+    );
+  }
+  const prepared = await prepareItems(jobId, data, jwt, myceliaUrl);
+  await job.updateProgress({ stage: "prepared", processed: 0, total: prepared.items.length });
+
+  if (data.action === "dry_run") {
+    await Promise.all(prepared.items.map((item) => releaseClaim(item.objectId, jwt, myceliaUrl)));
+    const estimatedInputCharacters = prepared.requests.reduce(
+      (sum, request) => sum + JSON.stringify(request.body).length,
+      0,
+    );
+    return {
+      success: true,
+      dryRun: true,
+      model: data.model,
+      promptName: data.promptName,
+      promptVersion,
+      items: prepared.items.length,
+      skipped: prepared.skipped,
+      estimatedInputTokens: Math.ceil(estimatedInputCharacters / 4),
+      preview: prepared.items.slice(0, 10).map((item) => ({ objectId: item.objectId, customId: item.customId })),
+    };
+  }
+  if (!prepared.requests.length) {
+    return { success: true, submitted: false, items: 0, skipped: prepared.skipped, message: "No eligible conversations for batch submission" };
+  }
+
+  const llm = (input: any) => callResource("llm", input, { jwt, myceliaUrl });
+  let submitted: any;
+  try {
+    submitted = await llm({
+      action: "batch_submit",
+      endpoint: "/v1/chat/completions",
+      model: data.model,
+      requests: prepared.requests,
+    });
+  } catch (error) {
+    await Promise.all(prepared.items.map((item) => releaseClaim(item.objectId, jwt, myceliaUrl)));
+    if (isProviderWideError(error)) {
+      await mongo({
+        action: "updateOne",
+        collection: "openrouter_batch_control",
+        query: { _id: PROVIDER_CONTROL_ID },
+        update: {
+          $set: {
+            paused: true,
+            pausedAt: new Date(),
+            reason: error instanceof Error ? error.message.slice(0, 1000) : String(error).slice(0, 1000),
+          },
+        },
+        options: { upsert: true },
+      });
+    }
+    throw error;
+  }
+
+  if (!submitted?.id) {
+    await Promise.all(prepared.items.map((item) => releaseClaim(item.objectId, jwt, myceliaUrl)));
+    throw new Error("OpenRouter accepted no batch id");
+  }
+  await mongo({
+    action: "insertOne",
+    collection: "openrouter_batches",
+    doc: {
+      batchId: submitted.id,
+      ownerJobId: jobId,
+      task: data.task,
+      endpoint: "/v1/chat/completions",
+      model: data.model,
+      prompt: data.prompt,
+      promptName: data.promptName,
+      promptVersion,
+      status: submitted.status ?? "validating",
+      requestCounts: submitted.request_counts,
+      items: prepared.items,
+      submittedAt: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  await job.updateProgress({ stage: "submitted", processed: 0, total: prepared.items.length, batchId: submitted.id });
+  return { success: true, submitted: true, batchId: submitted.id, status: submitted.status, items: prepared.items.length, skipped: prepared.skipped, completionWindow: submitted.completion_window ?? "24h" };
+}
+
+async function poll(job: Job<JobData>): Promise<JobResult> {
+  const jwt = Deno.env.get("MYCELIA_JWT")!;
+  const myceliaUrl = Deno.env.get("MYCELIA_URL")!;
+  const mongo = (input: any) => callResource("mongo", input, { jwt, myceliaUrl });
+  const llm = (input: any) => callResource("llm", input, { jwt, myceliaUrl });
+  const batches = await mongo({
+    action: "find",
+    collection: "openrouter_batches",
+    query: { status: { $in: ACTIVE_BATCH_STATES } },
+    options: { sort: { submittedAt: 1 }, limit: 100 },
+  }) as Array<Record<string, any>>;
+  let imported = 0;
+  let failed = 0;
+  let checked = 0;
+
+  for (const batch of batches) {
+    checked++;
+    let batchImported = 0;
+    let batchFailed = 0;
+    const remote = await llm({ action: "batch_get", batchId: batch.batchId }) as Record<string, any>;
+    const update: Record<string, unknown> = {
+      status: remote.status,
+      requestCounts: remote.request_counts,
+      usage: remote.usage,
+      updatedAt: new Date(),
+      ...(TERMINAL_BATCH_STATES.includes(remote.status) ? { completedAt: new Date() } : {}),
+    };
+    if (remote.status === "completed" && Array.isArray(remote.results)) {
+      const itemsById = new Map<string, BatchItem>(
+        (batch.items ?? []).map((item: BatchItem) => [item.customId, item]),
+      );
+      const itemResults: Array<Record<string, unknown>> = [];
+      const seenCustomIds = new Set<string>();
+      for (const result of remote.results) {
+        const item = itemsById.get(result.custom_id);
+        if (!item) continue;
+        seenCustomIds.add(item.customId);
+        try {
+          if (!result.response?.body) throw new Error(result.error?.message ?? "Batch item returned no response body");
+          const completion = {
+            ...result.response.body,
+            mycelia_routing: {
+              requestedModel: batch.model,
+              resolvedModel: result.response.body.model ?? batch.model,
+              fallbackUsed: false,
+              providerBaseUrl: "https://openrouter.ai/api/v1",
+              promptCaching: { enabled: true },
+            },
+          };
+          const text = getChatCompletionText(completion, {
+            requestedModel: batch.model,
+            resolvedModel: completion.mycelia_routing.resolvedModel,
+            purpose: "batched conversation summary",
+          });
+          const entry = createLLMSummaryEntry(text, completion, batch.prompt, {
+            type: "summarization",
+            prompt: batch.prompt,
+            promptName: batch.promptName,
+            model: batch.model,
+            fallbackModel: "",
+            allowExisting: false,
+            retryNow: false,
+            minDurationForLlm: 10,
+          }, batch.ownerJobId, item.sourceRefs);
+          const saved = await updateObjectSummaries(item.objectId, entry, false, jwt, myceliaUrl);
+          await releaseClaim(item.objectId, jwt, myceliaUrl);
+          if (!saved.skipped) {
+            imported++;
+            batchImported++;
+          }
+          itemResults.push({ customId: item.customId, objectId: item.objectId, status: saved.skipped ? "skipped" : "imported" });
+        } catch (error) {
+          failed++;
+          batchFailed++;
+          await releaseClaim(item.objectId, jwt, myceliaUrl);
+          itemResults.push({ customId: item.customId, objectId: item.objectId, status: "failed", error: error instanceof Error ? error.message.slice(0, 1000) : String(error) });
+        }
+      }
+      for (const item of itemsById.values()) {
+        if (seenCustomIds.has(item.customId)) continue;
+        failed++;
+        batchFailed++;
+        await releaseClaim(item.objectId, jwt, myceliaUrl);
+        itemResults.push({ customId: item.customId, objectId: item.objectId, status: "failed", error: "Batch completed without an item result" });
+      }
+      update.importedAt = new Date();
+      update.itemResults = itemResults;
+      update.importCounts = { imported: batchImported, failed: batchFailed };
+    } else if (TERMINAL_BATCH_STATES.includes(remote.status)) {
+      await Promise.all((batch.items ?? []).map((item: BatchItem) => releaseClaim(item.objectId, jwt, myceliaUrl)));
+    }
+    await mongo({ action: "updateOne", collection: "openrouter_batches", query: { _id: batch._id }, update: { $set: update } });
+    await job.updateProgress({ stage: "polling", processed: checked, total: batches.length, imported, failed });
+  }
+  return { success: true, checked, imported, failed, processed: checked };
+}
+
+const submitCapability: JobCapability = {
+  name: "openrouter_batch",
+  maxConcurrency: 1,
+  inputSchema: z.toJSONSchema(schema),
+  outputSchema: z.toJSONSchema(z.object({ success: z.boolean(), batchId: z.string().optional(), items: z.number().optional(), dryRun: z.boolean().optional() })),
+  policies: [
+    { resource: "db/transcriptions", action: "read", effect: "allow" },
+    { resource: "db/openrouter_batches", action: "*", effect: "allow" },
+    { resource: "db/openrouter_batch_control", action: "*", effect: "allow" },
+    { resource: "llm/chat", action: "batch_submit", effect: "allow" },
+    { resource: "objects", action: "*", effect: "allow" },
+  ],
+  use: submit,
+};
+
+export const pollCapability: JobCapability = {
+  name: "openrouter_batch_poll",
+  maxConcurrency: 1,
+  inputSchema: z.toJSONSchema(pollSchema),
+  outputSchema: z.toJSONSchema(z.object({ success: z.boolean(), checked: z.number(), imported: z.number(), failed: z.number(), processed: z.number() })),
+  policies: [
+    { resource: "db/openrouter_batches", action: "*", effect: "allow" },
+    { resource: "llm/chat", action: "batch_get", effect: "allow" },
+    { resource: "objects", action: "*", effect: "allow" },
+  ],
+  use: poll,
+  triggers: { sources: [], interval: 300 },
+};
+
+export default submitCapability;

--- a/backend/workers/openrouter_batch_poll.ts
+++ b/backend/workers/openrouter_batch_poll.ts
@@ -1,0 +1,1 @@
+export { pollCapability as default } from "./openrouter_batch.ts";

--- a/backend/workers/summarization.test.ts
+++ b/backend/workers/summarization.test.ts
@@ -2,6 +2,7 @@ import { expect } from "@std/expect";
 import {
   buildSummarySourceRefs,
   getSummarizationRetryDelayMs,
+  isConversationClaimActive,
   isTerminalSummarizationResponseError,
 } from "./summarization.ts";
 
@@ -9,6 +10,18 @@ Deno.test("summarization retries back off and remain bounded", () => {
   expect(getSummarizationRetryDelayMs(1)).toBe(15 * 60 * 1000);
   expect(getSummarizationRetryDelayMs(2)).toBe(30 * 60 * 1000);
   expect(getSummarizationRetryDelayMs(99)).toBe(24 * 60 * 60 * 1000);
+});
+
+Deno.test("a batch claim stays active beyond the normal worker timeout", () => {
+  const now = Date.parse("2026-07-30T00:30:00.000Z");
+  expect(isConversationClaimActive({
+    startedAt: "2026-07-30T00:00:00.000Z",
+    holdUntil: "2026-07-31T00:00:00.000Z",
+  }, now)).toBe(true);
+  expect(isConversationClaimActive({
+    startedAt: "2026-07-30T00:00:00.000Z",
+    holdUntil: "2026-07-30T00:20:00.000Z",
+  }, now)).toBe(false);
 });
 
 Deno.test("summary source receipt records exact chunks and transcripts", () => {

--- a/backend/workers/summarization.ts
+++ b/backend/workers/summarization.ts
@@ -126,7 +126,7 @@ export function buildSummarySourceRefs(
   };
 }
 
-function getConversationSourceContext(obj: any): SummarySourceContext {
+export function getConversationSourceContext(obj: any): SummarySourceContext {
   const conversationId = stringId(obj?._id) ?? undefined;
   const chunkId = stringId(obj?.metadata?.extractedWith?.chunkId);
   const extractorJobId = stringId(obj?.metadata?.extractedWith?.jobId) ??
@@ -147,11 +147,11 @@ function getSilenceMessage(gapMs: number): string {
   return `[Silence ${duration}m]`;
 }
 
-function hasNoSummaries(obj: any): boolean {
+export function hasNoSummaries(obj: any): boolean {
   return !Array.isArray(obj?.summaries) || obj.summaries.length === 0;
 }
 
-function getConversationRange(obj: any): { start: Date; end: Date } | null {
+export function getConversationRange(obj: any): { start: Date; end: Date } | null {
   const ranges = Array.isArray(obj?.timeRanges) ? obj.timeRanges : [];
   const parsed = ranges
     .map((range: any) => ({
@@ -201,7 +201,7 @@ async function loadTranscripts(
   }, { jwt, myceliaUrl });
 }
 
-function buildPromptFromTranscripts(transcripts: any[]): string {
+export function buildPromptFromTranscripts(transcripts: any[]): string {
   let promptText = "";
   let lastEnd = new Date(transcripts[0].start).getTime();
   promptText += getTimestampMessage(new Date(transcripts[0].start)) + "\n";
@@ -251,7 +251,7 @@ function createTranscriptSummaryEntry(
   };
 }
 
-function createLLMSummaryEntry(
+export function createLLMSummaryEntry(
   summary: string,
   completion: any,
   systemPrompt: string,
@@ -294,7 +294,7 @@ function createLLMSummaryEntry(
   };
 }
 
-async function updateObjectSummaries(
+export async function updateObjectSummaries(
   existingObjectId: string,
   summaryEntry: any,
   allowExisting: boolean,
@@ -423,6 +423,25 @@ const JOB_TIMEOUT_MS = 15 * 60 * 1000;
 const SUMMARIZATION_RETRY_BASE_MS = 15 * 60 * 1000;
 const SUMMARIZATION_RETRY_MAX_MS = 24 * 60 * 60 * 1000;
 
+type ConversationClaimOptions = {
+  // A Batch request is allowed to wait up to 24 hours. Its claim must outlive
+  // the normal worker timeout or a synchronous summary worker can duplicate
+  // the same LLM work while OpenRouter still owns the request.
+  holdUntil?: Date;
+  kind?: "openrouter_batch";
+};
+
+export function isConversationClaimActive(
+  claim: { startedAt?: string; holdUntil?: string } | null | undefined,
+  now = Date.now(),
+): boolean {
+  if (!claim?.startedAt) return false;
+  const heldUntil = claim.holdUntil ? new Date(claim.holdUntil).getTime() : 0;
+  if (Number.isFinite(heldUntil) && heldUntil > now) return true;
+  const claimAge = now - new Date(claim.startedAt).getTime();
+  return Number.isFinite(claimAge) && claimAge < JOB_TIMEOUT_MS;
+}
+
 export function getSummarizationRetryDelayMs(attempt: number): number {
   const safeAttempt = Math.max(1, Math.floor(attempt));
   return Math.min(
@@ -486,11 +505,12 @@ async function setSummarizationFailure(
   }
 }
 
-async function claimConversation(
+export async function claimConversation(
   objectId: string,
   jobId: string,
   jwt: string,
   myceliaUrl: string,
+  options: ConversationClaimOptions = {},
 ): Promise<boolean> {
   const obj = await callResource<ObjectsRequest, ObjectsResponse>("objects", {
     action: "get",
@@ -503,8 +523,7 @@ async function claimConversation(
   // Check if already claimed by another (non-timed-out) job
   const claim = obj._summarizationClaim;
   if (claim?.startedAt) {
-    const claimAge = Date.now() - new Date(claim.startedAt).getTime();
-    if (claimAge < JOB_TIMEOUT_MS) {
+    if (isConversationClaimActive(claim)) {
       console.log(
         `[summarization] Object ${objectId} already claimed by job ${claim.jobId}, skipping`,
       );
@@ -521,7 +540,14 @@ async function claimConversation(
       id: objectId,
       version: obj.version ?? 0,
       field: "_summarizationClaim",
-      value: { jobId, startedAt: new Date().toISOString() },
+      value: {
+        jobId,
+        startedAt: new Date().toISOString(),
+        ...(options.holdUntil ? {
+          holdUntil: options.holdUntil.toISOString(),
+          kind: options.kind,
+        } : {}),
+      },
     }, { jwt, myceliaUrl });
     return true;
   } catch {
@@ -532,7 +558,7 @@ async function claimConversation(
   }
 }
 
-async function releaseClaim(
+export async function releaseClaim(
   objectId: string,
   jwt: string,
   myceliaUrl: string,

--- a/frontend/src/pages/JobsPage.tsx
+++ b/frontend/src/pages/JobsPage.tsx
@@ -29,11 +29,13 @@ import {
   ArrowDown,
   ArrowUp,
   ArrowUpDown,
+  Ban,
   Check,
   CheckCircle,
   ChevronDown,
   Clock,
   Copy,
+  Layers,
   PauseCircle,
   Play,
   PlayCircle,
@@ -164,6 +166,25 @@ type VadJobFormData = {
   originalId?: string;
   start?: Date;
   end?: Date;
+};
+
+type OpenRouterBatch = {
+  id: string;
+  batchId: string;
+  task: string;
+  model: string;
+  status: string;
+  requestCounts?: { total?: number; completed?: number; failed?: number };
+  usage?: { cost?: number; prompt_tokens?: number; completion_tokens?: number };
+  submittedAt?: string;
+  completedAt?: string;
+  importCounts?: { imported?: number; failed?: number };
+};
+
+type OpenRouterBatchControl = {
+  paused: boolean;
+  reason?: string;
+  pausedAt?: string;
 };
 
 /**
@@ -1167,6 +1188,38 @@ export default function JobsPage() {
       await api.callResource("config", {
         action: "get",
       }) as InferenceRoutingConfig,
+  });
+
+  const { data: openRouterBatches = [], refetch: refetchOpenRouterBatches } = useQuery({
+    queryKey: ["openrouter-batches"],
+    queryFn: async () => await api.callResource("jobs", {
+      action: "openrouter_batch_list",
+      limit: 25,
+    }) as OpenRouterBatch[],
+    refetchInterval: 30_000,
+  });
+
+  const cancelOpenRouterBatchMutation = useMutation({
+    mutationFn: async (id: string) => await api.callResource("jobs", {
+      action: "openrouter_batch_cancel",
+      id,
+    }),
+    onSuccess: () => void refetchOpenRouterBatches(),
+  });
+
+  const { data: openRouterBatchControl, refetch: refetchOpenRouterBatchControl } = useQuery({
+    queryKey: ["openrouter-batch-control"],
+    queryFn: async () => await api.callResource("jobs", {
+      action: "openrouter_batch_control",
+    }) as OpenRouterBatchControl,
+    refetchInterval: 30_000,
+  });
+
+  const resumeOpenRouterBatchMutation = useMutation({
+    mutationFn: async () => await api.callResource("jobs", {
+      action: "openrouter_batch_resume",
+    }),
+    onSuccess: () => void refetchOpenRouterBatchControl(),
   });
 
   useEffect(() => {
@@ -2206,6 +2259,71 @@ export default function JobsPage() {
           </Button>
         </div>
       </div>
+
+      {(openRouterBatches.length > 0 || openRouterBatchControl?.paused) && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Layers className="h-5 w-5" />
+              OpenRouter batches
+              <Badge variant="outline">24h async</Badge>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {openRouterBatchControl?.paused && (
+              <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-amber-500/50 bg-amber-500/5 p-3">
+                <div className="text-sm">
+                  <span className="font-medium text-amber-600 dark:text-amber-400">New submissions paused.</span>
+                  {openRouterBatchControl.reason ? ` ${openRouterBatchControl.reason}` : " Resolve the provider-wide error before continuing."}
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => resumeOpenRouterBatchMutation.mutate()}
+                  disabled={resumeOpenRouterBatchMutation.isPending}
+                >
+                  <Play className="mr-2 h-4 w-4" /> Resume submissions
+                </Button>
+              </div>
+            )}
+            {openRouterBatches.map((batch) => {
+              const submittedAt = batch.submittedAt ? new Date(batch.submittedAt) : null;
+              const finishedAt = batch.completedAt ? new Date(batch.completedAt) : null;
+              const elapsed = submittedAt
+                ? formatJobDuration(submittedAt.getTime(), finishedAt?.getTime())
+                : null;
+              const terminal = ["completed", "failed", "expired", "cancelled"].includes(batch.status);
+              return (
+                <div key={batch.id} className="flex flex-wrap items-center justify-between gap-3 rounded-md border p-3">
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant={terminal ? "secondary" : "outline"}>{batch.status}</Badge>
+                      <span className="font-mono text-xs">{batch.model}</span>
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      {batch.requestCounts?.completed ?? 0}/{batch.requestCounts?.total ?? 0} completed
+                      {batch.requestCounts?.failed ? ` · ${batch.requestCounts.failed} provider failed` : ""}
+                      {batch.importCounts ? ` · ${batch.importCounts.imported ?? 0} imported` : ""}
+                      {elapsed !== null ? ` · ${elapsed} elapsed` : ""}
+                      {typeof batch.usage?.cost === "number" ? ` · $${batch.usage.cost.toFixed(6)}` : ""}
+                    </div>
+                  </div>
+                  {!terminal && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => cancelOpenRouterBatchMutation.mutate(batch.id)}
+                      disabled={cancelOpenRouterBatchMutation.isPending}
+                    >
+                      <Ban className="mr-2 h-4 w-4" /> Cancel batch
+                    </Button>
+                  )}
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      )}
 
       {pausedPipelineWorkers.length > 0 && (
         <Card className="border-amber-500/50 bg-amber-500/5">


### PR DESCRIPTION
## Status
WIP — blocked by an OpenRouter-side Batch API issue. Both DeepSeek V4 Flash and GPT-4o probes returned HTTP 404 from `/api/beta/batches`.

## What this PR contains
- OpenRouter Batch submit/poll/cancel/import workflow for homogeneous summarization tasks.
- Lifecycle persistence, idempotent result import, per-item errors, and operator controls.
- GPT-4o compatibility probe while keeping DeepSeek as the production default.

## Why separate
Batching is removed from `sky-uat` until OpenRouter fixes or documents the endpoint availability. The implementation remains available here for re-testing.

## Validation
- Deno type check passed for the batch worker.
- Focused batch worker test passed.
- Live probes against DeepSeek V4 Flash and GPT-4o both reproduced the provider HTTP 404.

## Next step
Re-test when OpenRouter confirms Batch API availability, then merge selectively into UAT.